### PR TITLE
PLATFORM-127: add known bad inputs rule and allow users to add custom rules and flood protection threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,56 @@ CrossAccountDomainDelegation(
 <details>
     <summary>Web Application Firewall</summary>
 
-Deploys AWS WAF using a
-vendored [AWS WAF Security Automations v3.2.0](https://github.com/awslabs/aws-waf-security-automations/tree/v3.2.0)
-template.
-For the available WAF configuration options see the "Parameters" section in
-the [original template](ca_cdk_constructs/edge_services/assets/aws-waf-security-automations.json)
+Deploys AWS WAF using a vendored
+[AWS WAF Security Automations v3.2.0](https://github.com/awslabs/aws-waf-security-automations/tree/v3.2.0)
+template, with the addition of the AWS Managed `KnownBadInputs` Rule (to protect specifically
+against the `log4j` vulnerability). It also allows for the addition of any additional user-defined
+custom rules, by supplying a list of one or more `CfnWebACL.RuleProperty`. TO NOTE: these may
+incur additional costs, if they take the total number of `WCUs` for the WAF above `1500`.
+
+In able to accommodate custom rules, and because of the limitations on working with imported
+nested templates with the CDK, the WAF provides a fixed set of standard rules - which is NOT
+parameterised in the `ProtectedCloudfront` construct. In order to vary the rules (e.g. add
+more of the standard rules, override any rules to COUNT, etc) you will need to copy the
+construct code to your config repo and make the amendments directly in the construct and
+template(s):
+
+`SQL injection rule` - `BLOCK`
+
+`Cross-site scripting rule` - `BLOCK`
+
+`Flood protection rule` - `BLOCK`. A simple rate based rule, which blocks an individual IP
+address if average requests over a 5-minute period from that IP address exceed a user-supplied
+`RequestThreshold` and unblocks once they fall below this threshold again. CARE!! Given
+that many LCAs work from a fixed single IP address, this should not be set to too low a value.
+
+`Reputation lists rule` - `BLOCK`
+
+For the original WAF configuration options see the "Parameters" section in the
+[original template](ca_cdk_constructs/edge_services/assets/aws-waf-security-automations.json).
+
+Usage:
 
 ```python
 from ca_cdk_constructs.edge_services.waf_stack import WafStack
 
-WafStack(app, "Waf", params={
-    "ActivateCrossSiteScriptingProtectionParam": "no",
-    "ActivateSqlInjectionProtectionParam": "no",
-    # ....
+WafStack(app,
+        "Waf",
+        # The waf **MUST** be instantiated with the rule combination here. Only the
+        # flood_protection_threshold and custom_rules can be varied.
+        params={
+            "ActivateAWSManagedRulesParam": "yes",
+            "ActivateSqlInjectionProtectionParam": "yes",
+            "ActivateCrossSiteScriptingProtectionParam": "yes",
+            "ActivateHttpFloodProtectionParam": "yes - AWS WAF rate based rule",
+            "ActivateScannersProbesProtectionParam": "no",
+            "ActivateReputationListsProtectionParam": "yes",
+            "ActivateBadBotProtectionParam": "no",
+            # threshold requests in 5-minute period from any single IP before that
+            # IP is blocked.
+            "RequestThreshold": flood_protection_threshold, # default = 100
+        },
+        custom_rules: <list of aws_cdk.aws_wafv2.CfnWebACL.RuleProperty]> default = [],
 })
 
 ```
@@ -82,8 +119,12 @@ WafStack(app, "Waf", params={
 
 [protected_cloudfront](ca_cdk_constructs/edge_services/protected_cloudfront.py)
 
-Creates a Cloudfront distribution protected by AWS WAF. The distribution forwards a custom header
-that can be requested by downstream load balancers in order to prevent traffic from hitting them directly.
+Creates a Cloudfront distribution protected by the AWS WAF. The distribution forwards a
+custom header that can be requested by downstream load balancers in order to prevent traffic
+from hitting them directly.
+
+When using this library construct, the only properties of the WAF that can be specified
+are any custom rules to be added on top of the WAF (list of aws_cdk.aws_wafv2.CfnWebACL.RuleProperty)
 
 Usage:
 
@@ -97,11 +138,16 @@ app = App()
 
 hosted_zone =  # create or import a hosted zone
 
+custom_rules = # optionally specify a list of aws_cdk.aws_wafv2.CfnWebACL.RuleProperty
+
 # creates Cloudfront protected by WAF at myapp.<hosted_zone_domain>
 cdn = ProtectedCloudfrontStack(app, "ca-referrals",
-                               hosted_zone=hosted_zone,
-                               sub_domain="myapp",
-                               origin_domain="my-loadbalancer-url")
+                                    hosted_zone=hosted_zone,
+                                    sub_domain="myapp",
+                                    origin_domain="my-loadbalancer-url"
+                                    custom_rules=custom_rules,
+                                    flood_protection_threshold="2500" # any value >= 100
+                               )
 
 # retrieve the secret header which must be added to the load balancer in order
 # to prevent users bypassing the CDN ( and the WAF )

--- a/ca_cdk_constructs/edge_services/protected_cloudfront.py
+++ b/ca_cdk_constructs/edge_services/protected_cloudfront.py
@@ -25,30 +25,52 @@ class ProtectedCloudfrontStack(Construct):
     ) -> None:
         super().__init__(scope, construct_id)
         self.domain_name = f"{sub_domain}.{hosted_zone.zone_name}"
-        # cloudfront log bucket
+
+        # the cloudfront log bucket - doesn't need to be us-east-1
+        # as no scanners & probes rule
         self._access_logs_bucket = s3.Bucket(
             self,
-            "CloudfrontLogBucket",
+            "CloudfrontLogsBucket",
             bucket_name=PhysicalName.GENERATE_IF_NEEDED,
             removal_policy=RemovalPolicy.DESTROY,
             lifecycle_rules=[s3.LifecycleRule(enabled=True, expiration=Duration.days(31 * 6))],
         )
 
-        # the waf automations solution stack deployed from the template in the assets/ folder
-        self._waf = WafStack(
+        # and waf automations solution stack deployed from the template in the waf_assets/ folder
+        self.waf = WafStack(
             self,
             "WafStack",
             params={
+                #### CARE!!!!
+                # At the moment, in order to be able to add the AWS known bad
+                # inputs rule, I've had to effectively hard-code the rule
+                # configurations in the *nested* waf template (ie comment out the
+                # conditions where the parameter value is "yes" and comment out
+                # resources where the parameter value is "no"). If you change the
+                # yes/no values here, you MUST make the corresponding changes in
+                # waf_assets/nested_template.yaml for them to take effect.
+                # See https://citizensadvice.atlassian.net/browse/OPS-4803
+                # Priority order set here - leave 2-9 for any custom rules added in
+                # addition to this template
+                # 0: whitelist rule
+                # 1: blacklist rule
+                # 10: aws core managed rule - condition commented out
+                # NO flood log-parser rule - rule commented out
+                # 11: flood rate-based rule - condition commented out
+                # NO scanners & probes rule - rule commented out
+                # 12: reputation list rule - condition commented out
+                # NO bad bot rule - rule commented out
+                # 20: sql injection - condition commented out
+                # 30: cross-site scripting (xss) - condition commented out
                 "ActivateAWSManagedRulesParam": "yes",
                 "ActivateSqlInjectionProtectionParam": "yes",
                 "ActivateCrossSiteScriptingProtectionParam": "yes",
-                "ActivateHttpFloodProtectionParam": "yes",
-                "ActivateScannersProbesProtectionParam": "yes",
+                "ActivateHttpFloodProtectionParam": "yes - AWS WAF rate based rule",
+                "ActivateScannersProbesProtectionParam": "no",
                 "ActivateReputationListsProtectionParam": "yes",
                 "ActivateBadBotProtectionParam": "no",
-                "AppAccessLogBucket": self._access_logs_bucket.bucket_name,
+                "RequestThreshold": "100",  # default and min for rate based flood protection = 100
             },
-            # waf and the cloudfront log bucket must be deployed to us-east-1
             env=Environment(region="us-east-1"),
         )
 
@@ -57,7 +79,7 @@ class ProtectedCloudfrontStack(Construct):
         #   Cross stack references are only supported for stacks deployed to the same environment or between nested stacks and their parent stack"
         # so this is a workaround - the waf template outputs (in us-east-1) are retrieved by a lambda in eu-west-1
         # RemoteOutputs is provided by the cdk-remote-stack library
-        waf_outputs = RemoteOutputs(self, "Outputs", stack=self._waf)
+        waf_outputs = RemoteOutputs(self, "Outputs", stack=self.waf)
 
         self._secret_header = Stack.of(self).stack_name
 
@@ -115,7 +137,7 @@ class ProtectedCloudfrontStack(Construct):
             viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         )
 
-        cdn.node.add_dependency(self._waf)
+        cdn.node.add_dependency(self.waf)
 
         self._cdn = cdn
 
@@ -142,7 +164,7 @@ class ProtectedCloudfrontStack(Construct):
 
     @property
     def waf_stack(self) -> Stack:
-        return self._waf
+        return self.waf
 
     @property
     def secret_header_value(self) -> str:

--- a/ca_cdk_constructs/edge_services/waf_assets/aws-waf-security-automations.json
+++ b/ca_cdk_constructs/edge_services/waf_assets/aws-waf-security-automations.json
@@ -598,27 +598,7 @@
             "Type": "AWS::CloudFormation::Stack",
             "DependsOn": "CheckRequirements",
             "Properties": {
-                "TemplateURL": {
-                    "Fn::Sub": [
-                        "https://${S3Bucket}.s3.amazonaws.com/${KeyPrefix}/aws-waf-security-automations-webacl.template",
-                        {
-                            "S3Bucket": {
-                                "Fn::FindInMap": [
-                                    "SourceCode",
-                                    "General",
-                                    "TemplateBucket"
-                                ]
-                            },
-                            "KeyPrefix": {
-                                "Fn::FindInMap": [
-                                    "SourceCode",
-                                    "General",
-                                    "KeyPrefix"
-                                ]
-                            }
-                        }
-                    ]
-                },
+                "TemplateURL": "AWS::NoValue",
                 "Parameters": {
                     "ActivateAWSManagedRulesParam": {
                         "Ref": "ActivateAWSManagedRulesParam"

--- a/ca_cdk_constructs/edge_services/waf_assets/known_bad_inputs_rule.py
+++ b/ca_cdk_constructs/edge_services/waf_assets/known_bad_inputs_rule.py
@@ -1,0 +1,29 @@
+import aws_cdk.aws_wafv2 as wafv2
+
+# this is the AWS Managed Rule: AWSManagedRulesKnownBadInputsRuleSet which we include
+# in all our WAFs to guard against the log4j vulnerability
+
+
+def known_bad_inputs_rule():
+    return [
+        ### AWS managed rule - needed to protect against log4j vulnerability
+        wafv2.CfnWebACL.RuleProperty(
+            name="AWS-AWSManagedRulesKnownBadInputsRuleSet",
+            priority=6,
+            statement=wafv2.CfnWebACL.StatementProperty(
+                managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
+                    name="AWSManagedRulesKnownBadInputsRuleSet",
+                    vendor_name="AWS",
+                )
+            ),
+            visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                cloud_watch_metrics_enabled=True,
+                metric_name="AWSManagedRulesKnownBadInputsRuleSet",
+                sampled_requests_enabled=True,
+            ),
+            override_action=wafv2.CfnWebACL.OverrideActionProperty(
+                # assigning to none means it will take the default action rather than count.
+                none=wafv2.CfnWebACL.CountActionProperty()
+            ),
+        ),
+    ]

--- a/ca_cdk_constructs/edge_services/waf_assets/nested_template.yaml
+++ b/ca_cdk_constructs/edge_services/waf_assets/nested_template.yaml
@@ -1,0 +1,795 @@
+#### CARE!!!!
+# At the moment, in order to be able to add the custom casebook
+# whitelist rule, I've had to effectively hard-code the rule
+# configurations here to match the values set in the protected_cdn_stack
+# (i.e. comment out the conditions where the parameter value is "yes"
+# and comment out resources where the parameter value is "no"). If you change the
+# yes/no values in the protected_cdn stack, you MUST make the corresponding
+# changes here in order for them to take effect.
+# See https://citizensadvice.atlassian.net/browse/OPS-4803
+
+# Priority order set here - leave 2-9 for custom rules added on top of this template
+# 0: whitelist rule
+# 1: blacklist rule
+# 10: aws core managed rule - condition commented out
+# NO flood log-parser rule - rule commented out
+# 11: flood rate-based rule - condition commented out
+# NO scanners & probes rule - rule commented out
+# 12: reputation list rule - condition commented out
+# NO bad bot rule - rule commented out
+# 20: sql injection - condition commented out
+# 30: cross-site scripting (xss) - condition commented out
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  (SO0006-WebACL) - AWS WAF Security Automations v3.2.0: This AWS CloudFormation template helps
+  you provision the AWS WAF Security Automations stack without worrying about creating and
+  configuring the underlying AWS infrastructure.
+
+  **WARNING** This template creates an AWS WAF Web ACL and Amazon CloudWatch custom metrics.
+  You will be billed for the AWS resources used if you create a stack from this template.
+
+Parameters:
+  ActivateAWSManagedRulesParam:
+    Type: String
+  ActivateSqlInjectionProtectionParam:
+    Type: String
+  ActivateCrossSiteScriptingProtectionParam:
+    Type: String
+  ActivateHttpFloodProtectionParam:
+    Type: String
+  ActivateScannersProbesProtectionParam:
+    Type: String
+  ActivateReputationListsProtectionParam:
+    Type: String
+  ActivateBadBotProtectionParam:
+    Type: String
+  RequestThreshold:
+    Type: Number
+  RegionScope:
+    Type: String
+  ParentStackName:
+    Type: String
+  GlueAccessLogsDatabase:
+    Type: String
+  GlueAppAccessLogsTable:
+    Type: String
+  GlueWafAccessLogsTable:
+    Type: String
+  LogLevel:
+    Type: String
+
+Conditions:
+  AWSManagedRulesActivated: !Equals
+    - !Ref ActivateAWSManagedRulesParam
+    - 'yes'
+
+  SqlInjectionProtectionActivated: !Equals
+    - !Ref ActivateSqlInjectionProtectionParam
+    - 'yes'
+
+  CrossSiteScriptingProtectionActivated: !Equals
+    - !Ref ActivateCrossSiteScriptingProtectionParam
+    - 'yes'
+
+  HttpFloodProtectionRateBasedRuleActivated: !Equals
+    - !Ref ActivateHttpFloodProtectionParam
+    - 'yes - AWS WAF rate based rule'
+
+  HttpFloodLambdaLogParser: !Equals
+    - !Ref ActivateHttpFloodProtectionParam
+    - 'yes - AWS Lambda log parser'
+
+  HttpFloodAthenaLogParser: !Equals
+    - !Ref ActivateHttpFloodProtectionParam
+    - 'yes - Amazon Athena log parser'
+
+  HttpFloodProtectionLogParserActivated: !Or
+    - Condition: HttpFloodLambdaLogParser
+    - Condition: HttpFloodAthenaLogParser
+
+  ScannersProbesLambdaLogParser: !Equals
+    - !Ref ActivateScannersProbesProtectionParam
+    - 'yes - AWS Lambda log parser'
+
+  ScannersProbesAthenaLogParser: !Equals
+    - !Ref ActivateScannersProbesProtectionParam
+    - 'yes - Amazon Athena log parser'
+
+  ScannersProbesProtectionActivated: !Or
+    - Condition: ScannersProbesLambdaLogParser
+    - Condition: ScannersProbesAthenaLogParser
+
+  ReputationListsProtectionActivated: !Equals
+    - !Ref ActivateReputationListsProtectionParam
+    - 'yes'
+
+  BadBotProtectionActivated: !Equals
+    - !Ref ActivateBadBotProtectionParam
+    - 'yes'
+
+Mappings:
+  SourceCode:
+    General:
+      TemplateBucket: 'solutions-reference'
+      SourceBucket: 'solutions'
+      KeyPrefix: 'aws-waf-security-automations/v3.2.0'
+
+Resources:
+# Timers
+# There is a rate throttling issue when creating so many calls to create IPSet (1 TPS)
+# By daisychaining these timers at N second intervals we can pace the calls to create new IPSets
+# binding them with DependsOn to the right timer
+
+  TimerWhiteV4:
+    Type: 'Custom::Timer'
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerBlackV4:
+    Type: 'Custom::Timer'
+    DependsOn: TimerWhiteV4
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerHttpFloodV4:
+    Type: 'Custom::Timer'
+    DependsOn: TimerBlackV4
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerScannersV4:
+    Type: 'Custom::Timer'
+    DependsOn: TimerHttpFloodV4
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerReputationV4:
+    DependsOn: TimerScannersV4
+    Type: 'Custom::Timer'
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerBadBotV4:
+    Type: 'Custom::Timer'
+    DependsOn: TimerReputationV4
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerWhiteV6:
+    Type: 'Custom::Timer'
+    DependsOn: TimerBadBotV4
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerBlackV6:
+    Type: 'Custom::Timer'
+    DependsOn: TimerWhiteV6
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerHttpFloodV6:
+    Type: 'Custom::Timer'
+    DependsOn: TimerBlackV6
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerScannersV6:
+    Type: 'Custom::Timer'
+    DependsOn: TimerHttpFloodV6
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerReputationV6:
+    DependsOn: TimerScannersV6
+    Type: 'Custom::Timer'
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerBadBotV6:
+    Type: 'Custom::Timer'
+    DependsOn: TimerReputationV6
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+# IPV4 IPSets
+  WAFWhitelistSetV4:
+    Type: 'AWS::WAFv2::IPSet'
+    DependsOn: TimerWhiteV4
+    Properties:
+      Scope: !Sub '${RegionScope}'
+      IPAddressVersion: 'IPV4'
+      Name: !Sub '${ParentStackName}WhitelistSetIPV4'
+      Description: 'Allow List for IPV4 addresses'
+      Addresses: []
+
+  WAFBlacklistSetV4:
+    Type: 'AWS::WAFv2::IPSet'
+    DependsOn: TimerBlackV4
+    Properties:
+      Scope: !Sub '${RegionScope}'
+      IPAddressVersion: 'IPV4'
+      Name: !Sub '${ParentStackName}BlacklistSetIPV4'
+      Description: 'Block Denied List for IPV4 addresses'
+      Addresses: []
+
+#  WAFHttpFloodSetV4:
+#    Type: 'AWS::WAFv2::IPSet'
+#    Condition: HttpFloodProtectionLogParserActivated
+#    DependsOn: TimerHttpFloodV4
+#    Properties:
+#      Scope: !Sub '${RegionScope}'
+#      IPAddressVersion: 'IPV4'
+#      Name: !Sub '${ParentStackName}HTTPFloodSetIPV4'
+#      Description: 'Block HTTP Flood IPV4 addresses'
+#      Addresses: []
+
+#  WAFScannersProbesSetV4:
+#    Type: 'AWS::WAFv2::IPSet'
+#    Condition: ScannersProbesProtectionActivated
+#    DependsOn: TimerScannersV4
+#    Properties:
+#      Scope: !Sub '${RegionScope}'
+#      IPAddressVersion: 'IPV4'
+#      Name: !Sub '${ParentStackName}ScannersProbesSetIPV4'
+#      Description: 'Block Scanners/Probes IPV4 addresses'
+#      Addresses: []
+
+  WAFReputationListsSetV4:
+    Type: 'AWS::WAFv2::IPSet'
+#    Condition: ReputationListsProtectionActivated
+    DependsOn: TimerReputationV4
+    Properties:
+      Scope: !Sub '${RegionScope}'
+      IPAddressVersion: 'IPV4'
+      Name: !Sub '${ParentStackName}IPReputationListsSetIPV4'
+      Description: 'Block Reputation List IPV4 addresses'
+      Addresses: []
+ 
+#  WAFBadBotSetV4:
+#    Type: 'AWS::WAFv2::IPSet'
+#    Condition: BadBotProtectionActivated
+#    DependsOn: TimerBadBotV4
+#    Properties:
+#      Scope: !Sub '${RegionScope}'
+#      IPAddressVersion: 'IPV4'
+#      Name: !Sub '${ParentStackName}IPBadBotSetIPV4'
+#      Description: 'Block Bad Bot IPV4 addresses'
+#      Addresses: []
+
+# IPV6 IPSets
+# Introduced an artificial DependsOn property here on each of the previous IPSets to address
+# a rate throttling issue when creating so many calls to create IPSet
+# The rate limit is 1 call per second to the IPSet API
+  WAFWhitelistSetV6:
+    Type: 'AWS::WAFv2::IPSet'
+    DependsOn: TimerWhiteV6
+    Properties:
+      Scope: !Sub '${RegionScope}'
+      IPAddressVersion: IPV6
+      Name: !Sub '${ParentStackName}WhitelistSetIPV6'
+      Description: 'Allow list for IPV6 addresses'
+      Addresses: []
+
+  WAFBlacklistSetV6:
+    Type: 'AWS::WAFv2::IPSet'
+    DependsOn: TimerBlackV6
+    Properties:
+      Scope: !Sub '${RegionScope}'
+      IPAddressVersion: IPV6
+      Name: !Sub '${ParentStackName}BlacklistSetIPV6'
+      Description: 'Block Denied List for IPV6 addresses'
+      Addresses: []
+
+#  WAFHttpFloodSetV6:
+#    Type: 'AWS::WAFv2::IPSet'
+#    Condition: HttpFloodProtectionLogParserActivated
+#    DependsOn: TimerHttpFloodV6
+#    Properties:
+#      Scope: !Sub '${RegionScope}'
+#      IPAddressVersion: IPV6
+#      Name: !Sub '${ParentStackName}HTTPFloodSetIPV6'
+#      Description: 'Block HTTP Flood IPV6 addresses'
+#      Addresses: []
+
+#  WAFScannersProbesSetV6:
+#    Type: 'AWS::WAFv2::IPSet'
+#    Condition: ScannersProbesProtectionActivated
+#    DependsOn: TimerScannersV6
+#    Properties:
+#      Scope: !Sub '${RegionScope}'
+#      IPAddressVersion: IPV6
+#      Name: !Sub '${ParentStackName}ScannersProbesSetIPV6'
+#      Description: 'Block Scanners/Probes IPV6 addresses'
+#      Addresses: []
+
+  WAFReputationListsSetV6:
+    Type: 'AWS::WAFv2::IPSet'
+#    Condition: ReputationListsProtectionActivated
+    DependsOn: TimerReputationV6
+    Properties:
+      Scope: !Sub '${RegionScope}'
+      IPAddressVersion: IPV6
+      Name: !Sub '${ParentStackName}IPReputationListsSetIPV6'
+      Description: 'Block Reputation List IPV6 addresses'
+      Addresses: []
+
+#  WAFBadBotSetV6:
+#    Type: 'AWS::WAFv2::IPSet'
+#    Condition: BadBotProtectionActivated
+#    DependsOn: TimerBadBotV6
+#    Properties:
+#      Scope: !Sub '${RegionScope}'
+#      IPAddressVersion: IPV6
+#      Name: !Sub '${ParentStackName}IPBadBotSetIPV6'
+#      Description: 'Block Bad Bot IPV6 addresses'
+#      Addresses: []
+
+  LambdaRoleCustomTimer:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*CustomTimer*'
+
+  CustomTimer:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Description: >-
+        This lambda function counts X seconds and can be used to slow down component creation in CloudFormation
+      Handler: 'timer.lambda_handler'
+      Role: !GetAtt LambdaRoleCustomTimer.Arn
+      Code:
+        S3Bucket: !Join ['-', [!FindInMap ["SourceCode", "General", "SourceBucket"], !Ref 'AWS::Region']]
+        S3Key: !Join ['/', [!FindInMap ["SourceCode", "General", "KeyPrefix"], 'timer.zip']]
+      Runtime: python3.8
+      MemorySize: 128
+      Timeout: 300
+      Environment:
+        Variables:
+          SECONDS: '2'
+          LOG_LEVEL: !Ref LogLevel
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+        - id: W89
+          reason: There is no need to run this lambda in a VPC
+        - id: W92
+          reason: There is no need for Reserved Concurrency
+
+# Adding a (priority 0) rule for AWS Managed RuleSet, optionally triggered by params
+
+  WAFWebACL:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Name: !Ref 'ParentStackName'
+      Description: 'Custom WAFWebACL'
+      Scope: !Sub '${RegionScope}'
+      VisibilityConfig: 
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'WAFWebACL']]
+      DefaultAction:
+        Allow: {}
+      Rules:
+#        - !If
+#          - AWSManagedRulesActivated
+        - Name: AWS-AWSManagedRulesCommonRuleSet
+          Priority: 10
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: MetricForAMRCRS
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+#          - !Ref 'AWS::NoValue'
+        - Name: !Sub '${ParentStackName}WhitelistRule'
+          Priority: 0
+          Action:
+            Allow: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'WhitelistRule']]
+          Statement:
+            OrStatement:
+              Statements:
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFWhitelistSetV4.Arn
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFWhitelistSetV6.Arn
+        - Name: !Sub '${ParentStackName}BlacklistRule'
+          Priority: 1
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'BlacklistRule']]
+          Statement:
+            OrStatement:
+              Statements:
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFBlacklistSetV4.Arn
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFBlacklistSetV6.Arn
+#        - !If
+#          - HttpFloodProtectionLogParserActivated
+#          - Name: !Sub '${ParentStackName}HttpFloodRegularRule'
+#            Priority: 3
+#            Action:
+#              Block: {}
+#            VisibilityConfig:
+#              SampledRequestsEnabled: true
+#              CloudWatchMetricsEnabled: true
+#              MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'HttpFloodRegularRule']]
+#            Statement:
+#              OrStatement:
+#                Statements:
+#                  - IPSetReferenceStatement:
+#                      Arn: !GetAtt WAFHttpFloodSetV4.Arn
+#                  - IPSetReferenceStatement:
+#                      Arn: !GetAtt WAFHttpFloodSetV6.Arn
+#          - !Ref 'AWS::NoValue'
+#        - !If
+#          - HttpFloodProtectionRateBasedRuleActivated
+        - Name: !Sub '${ParentStackName}HttpFloodRateBasedRule'
+          Priority: 11
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'HttpFloodRateBasedRule']]
+          Statement:
+            RateBasedStatement:
+              AggregateKeyType: "IP"
+              Limit: !Ref RequestThreshold
+#          - !Ref 'AWS::NoValue'
+#        - !If
+#          - ScannersProbesProtectionActivated
+#        - Name: !Sub '${ParentStackName}ScannersAndProbesRule'
+#          Priority: 12
+#          Action:
+#            Block: {}
+#          VisibilityConfig:
+#            SampledRequestsEnabled: true
+#            CloudWatchMetricsEnabled: true
+#            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'ScannersProbesRule']]
+#          Statement:
+#            OrStatement:
+#              Statements:
+#                - IPSetReferenceStatement:
+#                    Arn: !GetAtt WAFScannersProbesSetV4.Arn
+#                - IPSetReferenceStatement:
+#                    Arn: !GetAtt WAFScannersProbesSetV6.Arn
+#          - !Ref 'AWS::NoValue'
+#        - !If
+#          - ReputationListsProtectionActivated
+        - Name: !Sub '${ParentStackName}IPReputationListsRule'
+          Priority: 12
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'IPReputationListsRule']]
+          Statement:
+            OrStatement:
+              Statements:
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFReputationListsSetV4.Arn
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFReputationListsSetV6.Arn
+#          - !Ref 'AWS::NoValue'
+#        - !If
+#          - BadBotProtectionActivated
+#          - Name: !Sub '${ParentStackName}BadBotRule'
+#            Priority: 7
+#            Action:
+#              Block: {}
+#            VisibilityConfig:
+#              SampledRequestsEnabled: true
+#              CloudWatchMetricsEnabled: true
+#              MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'BadBotRule']]
+#            Statement:
+#              OrStatement:
+#                Statements:
+#                  - IPSetReferenceStatement:
+#                      Arn: !GetAtt WAFBadBotSetV4.Arn
+#                  - IPSetReferenceStatement:
+#                      Arn: !GetAtt WAFBadBotSetV6.Arn
+#          - !Ref 'AWS::NoValue'
+#        - !If
+#          - SqlInjectionProtectionActivated
+        - Name: !Sub '${ParentStackName}SqlInjectionRule'
+          Priority: 20
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'SqlInjectionRule']]
+          Statement:
+            OrStatement:
+              Statements:
+                - SqliMatchStatement:
+                    FieldToMatch:
+                      QueryString: {}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - SqliMatchStatement:
+                    FieldToMatch:
+                      Body: {}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - SqliMatchStatement:
+                    FieldToMatch:
+                      UriPath: {}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - SqliMatchStatement:
+                    FieldToMatch:
+                      SingleHeader: {Name: "Authorization"}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - SqliMatchStatement:
+                    FieldToMatch:
+                      SingleHeader: {Name: "Cookie"}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+#          - !Ref 'AWS::NoValue'
+#        - !If
+#          - CrossSiteScriptingProtectionActivated
+        - Name: !Sub '${ParentStackName}XssRule'
+          Priority: 30
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'XssRule']]
+          Statement:
+            OrStatement:
+              Statements:
+                - XssMatchStatement:
+                    FieldToMatch:
+                      QueryString: {}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - XssMatchStatement:
+                    FieldToMatch:
+                      Body: {}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - XssMatchStatement:
+                    FieldToMatch:
+                      UriPath: {}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - XssMatchStatement:
+                    FieldToMatch:
+                      SingleHeader: {Name: "Cookie"}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+#          - !Ref 'AWS::NoValue'
+
+Outputs:
+# Arns
+  WAFWhitelistSetV4Arn:
+    Value: !GetAtt WAFWhitelistSetV4.Arn
+
+  WAFBlacklistSetV4Arn:
+    Value: !GetAtt WAFBlacklistSetV4.Arn
+
+#  WAFHttpFloodSetV4Arn:
+#    Value: !GetAtt WAFHttpFloodSetV4.Arn
+#    Condition: HttpFloodProtectionLogParserActivated
+
+#  WAFScannersProbesSetV4Arn:
+#    Value: !GetAtt WAFScannersProbesSetV4.Arn
+#    Condition: ScannersProbesProtectionActivated
+
+  WAFReputationListsSetV4Arn:
+    Value: !GetAtt WAFReputationListsSetV4.Arn
+    Condition: ReputationListsProtectionActivated
+
+#  WAFBadBotSetV4Arn:
+#    Value: !GetAtt WAFBadBotSetV4.Arn
+#    Condition: BadBotProtectionActivated
+
+  WAFWhitelistSetV6Arn:
+    Value: !GetAtt WAFWhitelistSetV6.Arn
+
+  WAFBlacklistSetV6Arn:
+    Value: !GetAtt WAFBlacklistSetV6.Arn
+
+#  WAFHttpFloodSetV6Arn:
+#    Value: !GetAtt WAFHttpFloodSetV6.Arn
+#    Condition: HttpFloodProtectionLogParserActivated
+
+#  WAFScannersProbesSetV6Arn:
+#    Value: !GetAtt WAFScannersProbesSetV6.Arn
+#    Condition: ScannersProbesProtectionActivated
+
+  WAFReputationListsSetV6Arn:
+    Value: !GetAtt WAFReputationListsSetV6.Arn
+    Condition: ReputationListsProtectionActivated
+
+#  WAFBadBotSetV6Arn:
+#    Value: !GetAtt WAFBadBotSetV6.Arn
+#    Condition: BadBotProtectionActivated
+
+# Names
+  NameWAFWhitelistSetV4:
+    Value: !Sub '${ParentStackName}WhitelistSetIPV4'
+
+  NameWAFBlacklistSetV4:
+    Value: !Sub '${ParentStackName}BlacklistSetIPV4'
+
+  NameHttpFloodSetV4:
+    Value: !Sub '${ParentStackName}HTTPFloodSetIPV4'
+    Condition: HttpFloodProtectionLogParserActivated
+
+#  NameScannersProbesSetV4:
+#    Value: !Sub '${ParentStackName}ScannersProbesSetIPV4'
+#    Condition: ScannersProbesProtectionActivated
+
+  NameReputationListsSetV4:
+    Value: !Sub '${ParentStackName}IPReputationListsSetIPV4'
+    Condition: ReputationListsProtectionActivated
+
+#  NameBadBotSetV4:
+#    Value: !Sub '${ParentStackName}IPBadBotSetIPV4'
+#    Condition: BadBotProtectionActivated
+
+  NameWAFWhitelistSetV6:
+    Value: !Sub '${ParentStackName}WhitelistSetIPV6'
+
+  NameWAFBlacklistSetV6:
+    Value: !Sub '${ParentStackName}BlacklistSetIPV6'
+
+  NameHttpFloodSetV6:
+    Value: !Sub '${ParentStackName}HTTPFloodSetIPV6'
+    Condition: HttpFloodProtectionLogParserActivated
+
+#  NameScannersProbesSetV6:
+#    Value: !Sub '${ParentStackName}ScannersProbesSetIPV6'
+#    Condition: ScannersProbesProtectionActivated
+
+  NameReputationListsSetV6:
+    Value: !Sub '${ParentStackName}IPReputationListsSetIPV6'
+    Condition: ReputationListsProtectionActivated
+
+#  NameBadBotSetV6:
+#    Value: !Sub '${ParentStackName}IPBadBotSetIPV6'
+#    Condition: BadBotProtectionActivated
+
+  GlueAccessLogsDatabase:
+    Value: !Ref GlueAccessLogsDatabase
+
+  GlueAppAccessLogsTable:
+    Value: !Ref GlueAppAccessLogsTable
+
+  GlueWafAccessLogsTable:
+    Value: !Ref GlueWafAccessLogsTable
+
+  WAFWebACL:
+    Value: !Ref WAFWebACL
+
+  WAFWebACLArn:
+    Value: !GetAtt WAFWebACL.Arn
+
+  WAFWebACLMetricName:
+    Value: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'MaliciousRequesters']]
+
+  IPReputationListsMetricName:
+    Value: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'IPReputationListsRule']]
+
+  Version:
+    Value: "v3.2.0"
+
+# Ids
+  WAFWhitelistSetV4Id:
+    Value: !GetAtt WAFWhitelistSetV4.Id
+
+  WAFBlacklistSetV4Id:
+    Value: !GetAtt WAFBlacklistSetV4.Id
+
+#  WAFHttpFloodSetV4Id:
+#    Value: !GetAtt WAFHttpFloodSetV4.Id
+#    Condition: HttpFloodProtectionLogParserActivated
+
+#  WAFScannersProbesSetV4Id:
+#    Value: !GetAtt WAFScannersProbesSetV4.Id
+#    Condition: ScannersProbesProtectionActivated
+
+  WAFReputationListsSetV4Id:
+    Value: !GetAtt WAFReputationListsSetV4.Id
+    Condition: ReputationListsProtectionActivated
+
+#  WAFBadBotSetV4Id:
+#    Value: !GetAtt WAFBadBotSetV4.Id
+#    Condition: BadBotProtectionActivated
+
+  WAFWhitelistSetV6Id:
+    Value: !GetAtt WAFWhitelistSetV6.Id
+
+  WAFBlacklistSetV6Id:
+    Value: !GetAtt WAFBlacklistSetV6.Id
+
+#  WAFHttpFloodSetV6Id:
+#    Value: !GetAtt WAFHttpFloodSetV6.Id
+#    Condition: HttpFloodProtectionLogParserActivated
+
+#  WAFScannersProbesSetV6Id:
+#    Value: !GetAtt WAFScannersProbesSetV6.Id
+#    Condition: ScannersProbesProtectionActivated
+
+  WAFReputationListsSetV6Id:
+    Value: !GetAtt WAFReputationListsSetV6.Id
+    Condition: ReputationListsProtectionActivated
+
+#  WAFBadBotSetV6Id:
+#    Value: !GetAtt WAFBadBotSetV6.Id
+#    Condition: BadBotProtectionActivated

--- a/ca_cdk_constructs/edge_services/waf_stack.py
+++ b/ca_cdk_constructs/edge_services/waf_stack.py
@@ -2,7 +2,9 @@ import os.path
 
 from aws_cdk import CfnOutput, Stack, PhysicalName, RemovalPolicy, Duration
 from aws_cdk.cloudformation_include import CfnInclude, CfnIncludeProps
+from aws_cdk import aws_wafv2 as wafv2
 from constructs import Construct
+from typing import Optional
 
 from ca_cdk_constructs.edge_services.waf_assets.known_bad_inputs_rule import (
     known_bad_inputs_rule,
@@ -27,7 +29,11 @@ from ca_cdk_constructs.edge_services.waf_assets.known_bad_inputs_rule import (
 
 class WafStack(Stack):
     # deploys the WAF automations solution stack using the template in the assets/ folder
-    def __init__(self, scope: Construct, id: str, params: dict, **kwargs) -> None:
+    def __init__(self, scope:
+            Construct, id: str,
+            params: dict,
+            custom_rules: Optional[wafv2.CfnWebACL.RuleProperty] = [],
+            **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         dirname = os.path.dirname(__file__)
@@ -53,6 +59,8 @@ class WafStack(Stack):
         rules = web_acl.rules
         # need to add aws managed known bad inputs rule
         web_acl.rules += list(known_bad_inputs_rule())
+        # need to add any user-supplied custom rules
+        web_acl.rules += custom_rules
 
     @property
     def acl(self) -> CfnOutput:

--- a/ca_cdk_constructs/edge_services/waf_stack.py
+++ b/ca_cdk_constructs/edge_services/waf_stack.py
@@ -1,8 +1,28 @@
 import os.path
 
-from aws_cdk import CfnOutput, Stack
-from aws_cdk.cloudformation_include import CfnInclude
+from aws_cdk import CfnOutput, Stack, PhysicalName, RemovalPolicy, Duration
+from aws_cdk.cloudformation_include import CfnInclude, CfnIncludeProps
 from constructs import Construct
+
+from ca_cdk_constructs.edge_services.waf_assets.known_bad_inputs_rule import (
+    known_bad_inputs_rule,
+)
+
+# Priority order set here: manually added rules...
+# 5: custom_casebook_whitelist
+# 6: aws known bad inputs rule
+
+# ... and from aws solution (leave 2-9 for custom rules)
+# 0: whitelist
+# 1: blacklist
+# 10: aws core managed rule
+# 11: flood rule
+# 12: flood rule
+# 13: scanners & probes
+# 14: reputation list
+#
+# 20: sql injection - set to COUNT
+# 30: cross-site scripting (xss) - set to COUNT
 
 
 class WafStack(Stack):
@@ -15,14 +35,25 @@ class WafStack(Stack):
         self.waf_stack = CfnInclude(
             self,
             "WafAutomationsTemplate",
-            template_file=os.path.join(dirname, "assets/aws-waf-security-automations.json"),
+            template_file=os.path.join(
+                dirname, "waf_assets/aws-waf-security-automations.json"
+            ),
+            load_nested_stacks={
+                "WebACLStack": CfnIncludeProps(
+                    template_file=os.path.join(dirname, "waf_assets/nested_template.yaml"),
+                )
+            },
             parameters=params,
         )
+
+        # retrieve the nested waf stack
+        nested_waf_stack = self.waf_stack.get_nested_stack("WebACLStack")
+        # retrieve the waf web acl resource, and access its rules attribute
+        web_acl = nested_waf_stack.included_template.get_resource(logical_id="WAFWebACL")
+        rules = web_acl.rules
+        # need to add aws managed known bad inputs rule
+        web_acl.rules += list(known_bad_inputs_rule())
 
     @property
     def acl(self) -> CfnOutput:
         return self.waf_stack.get_output(logical_id="WAFWebACL")
-
-    @property
-    def acl_arn(self) -> str:
-        return self.waf_stack.get_output(logical_id="WAFWebACLArn").value

--- a/tests/test_protected_cloudfront.py
+++ b/tests/test_protected_cloudfront.py
@@ -2,7 +2,7 @@ import aws_cdk as core
 import aws_cdk.assertions as assertions
 from aws_cdk.aws_route53 import HostedZone
 
-from ca_cdk_constructs.edge_services.protected_cloudfront import ProtectedCloudfrontStack
+from ca_cdk_constructs.edge_services.protected_cloudfront import ProtectedCloudfront
 
 
 def test_cloudfront_record_created():
@@ -11,7 +11,7 @@ def test_cloudfront_record_created():
     zone_stack = core.Stack(app, "HostedZoneStack", env=env)
     hosted_zone = HostedZone(zone_stack, "Hz", zone_name="test.acme.org.uk")
 
-    ProtectedCloudfrontStack(
+    ProtectedCloudfront(
         zone_stack,
         "Cdn",
         hosted_zone=hosted_zone,

--- a/tests/test_waf.py
+++ b/tests/test_waf.py
@@ -1,0 +1,88 @@
+import os.path
+
+import aws_cdk as core
+import aws_cdk.assertions as assertions
+from aws_cdk.aws_route53 import HostedZone
+from ca_cdk_constructs.edge_services.protected_cloudfront import ProtectedCloudfront
+from aws_cdk.cloudformation_include import CfnInclude, CfnIncludeProps
+
+from ca_cdk_constructs.edge_services.waf_stack import WafStack
+
+
+def test_waf_created():
+    app = core.App()
+    env = core.Environment(account="12345678901", region="us-east-1")
+    zone_stack = core.Stack(app, "ZoneStack", env=env)
+    hosted_zone = HostedZone(zone_stack, "Hz", zone_name="test.acme.org.uk")
+    cloudfront = ProtectedCloudfront(
+        zone_stack,
+        "Cdn",
+        hosted_zone=hosted_zone,
+        origin_domain="foo-lb.some.domain",
+        sub_domain="refer",
+    )
+
+    waf_stack = WafStack(
+            cloudfront,
+            "TestWafStack",
+            params={
+                "ActivateAWSManagedRulesParam": "yes",
+                "ActivateSqlInjectionProtectionParam": "yes",
+                "ActivateCrossSiteScriptingProtectionParam": "yes",
+                "ActivateHttpFloodProtectionParam": "yes - AWS WAF rate based rule",
+                "ActivateScannersProbesProtectionParam": "no",
+                "ActivateReputationListsProtectionParam": "yes",
+                "ActivateBadBotProtectionParam": "no",
+            },
+            env=env,
+            custom_rules=[],
+    )
+    template = assertions.Template.from_stack(waf_stack)
+
+    # not much we can test for, except that the waf stack has as one of its resource the nested
+    # WebACLStack stack from the AWS solution, and that this is using the same params as passed
+    # so users of the template will need to do their own testing/checks on the deployed waf
+    template.has_resource_properties(
+        "AWS::CloudFormation::Stack",
+            {"Parameters":
+                {
+                    "ActivateAWSManagedRulesParam": "yes",
+                    "ActivateSqlInjectionProtectionParam": "yes",
+                    "ActivateCrossSiteScriptingProtectionParam": "yes",
+                    "ActivateHttpFloodProtectionParam": "yes - AWS WAF rate based rule",
+                    "ActivateScannersProbesProtectionParam": "no",
+                    "ActivateReputationListsProtectionParam": "yes",
+                    "ActivateBadBotProtectionParam": "no",
+                },
+            }
+    )
+
+    dirname = os.path.dirname(__file__)
+
+    # TODO - don't think there's much we can test for in the WebACLStack itself, as you can't use
+    # Template.from_stack on a stack imported using CfnInclude - you get an error
+    # "...  Object of type 'aws-cdk-lib.cloudformation_include.CfnInclude' is not convertible to aws-cdk-lib.Stack"
+    # but just in case anyone else can find a way to do it, this is how you'd generate the stack
+    nested_waf_stack = CfnInclude(
+        waf_stack,
+        "TestWafAutomationsTemplate",
+        template_file=os.path.join(
+            dirname, "waf_assets/aws-waf-security-automations.json"
+        ),
+        load_nested_stacks={
+            "WebACLStack": CfnIncludeProps(
+                template_file=os.path.join(dirname, "waf_assets/nested_template.yaml"),
+            )
+        },
+        parameters={
+            "ActivateAWSManagedRulesParam": "yes",
+            "ActivateSqlInjectionProtectionParam": "yes",
+            "ActivateCrossSiteScriptingProtectionParam": "yes",
+            "ActivateHttpFloodProtectionParam": "yes - AWS WAF rate based rule",
+            "ActivateScannersProbesProtectionParam": "no",
+            "ActivateReputationListsProtectionParam": "yes",
+            "ActivateBadBotProtectionParam": "no",
+        },
+    )
+
+    # nested_template = assertions.Template.from_stack(nested_waf_stack)

--- a/tests/waf_assets/aws-waf-security-automations.json
+++ b/tests/waf_assets/aws-waf-security-automations.json
@@ -1,0 +1,5066 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "(SO0006) - AWS WAF Security Automations v3.2.0: This AWS CloudFormation template helps you provision the AWS WAF Security Automations stack without worrying about creating and configuring the underlying AWS infrastructure.\n**WARNING** This template creates multiple AWS Lambda functions, an AWS WAFv2 Web ACL, an Amazon S3 bucket, and an Amazon CloudWatch custom metric. You will be billed for the AWS resources used if you create a stack from this template.",
+    "Metadata": {
+        "AWS::CloudFormation::Interface": {
+            "ParameterGroups": [
+                {
+                    "Label": {
+                        "default": "Protection List"
+                    },
+                    "Parameters": [
+                        "ActivateAWSManagedRulesParam",
+                        "ActivateSqlInjectionProtectionParam",
+                        "ActivateCrossSiteScriptingProtectionParam",
+                        "ActivateHttpFloodProtectionParam",
+                        "ActivateScannersProbesProtectionParam",
+                        "ActivateReputationListsProtectionParam",
+                        "ActivateBadBotProtectionParam"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Log Monitoring Settings"
+                    },
+                    "Parameters": [
+                        "EndpointType",
+                        "AppAccessLogBucket",
+                        "ErrorThreshold",
+                        "RequestThreshold",
+                        "WAFBlockPeriod",
+                        "KeepDataInOriginalS3Location"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "IP Retention Settings"
+                    },
+                    "Parameters": [
+                        "IPRetentionPeriodAllowedParam",
+                        "IPRetentionPeriodDeniedParam",
+                        "SNSEmailParam"
+                    ]
+                }
+            ],
+            "ParameterLabels": {
+                "ActivateAWSManagedRulesParam": {
+                    "default": "Activate AWS Managed Rules Protection"
+                },
+                "ActivateSqlInjectionProtectionParam": {
+                    "default": "Activate SQL Injection Protection"
+                },
+                "ActivateCrossSiteScriptingProtectionParam": {
+                    "default": "Activate Cross-site Scripting Protection"
+                },
+                "ActivateHttpFloodProtectionParam": {
+                    "default": "Activate HTTP Flood Protection"
+                },
+                "ActivateScannersProbesProtectionParam": {
+                    "default": "Activate Scanner & Probe Protection"
+                },
+                "ActivateReputationListsProtectionParam": {
+                    "default": "Activate Reputation List Protection"
+                },
+                "ActivateBadBotProtectionParam": {
+                    "default": "Activate Bad Bot Protection"
+                },
+                "EndpointType": {
+                    "default": "Endpoint Type"
+                },
+                "AppAccessLogBucket": {
+                    "default": "Application Access Log Bucket Name"
+                },
+                "ErrorThreshold": {
+                    "default": "Error Threshold"
+                },
+                "RequestThreshold": {
+                    "default": "Request Threshold"
+                },
+                "WAFBlockPeriod": {
+                    "default": "WAF Block Period"
+                },
+                "KeepDataInOriginalS3Location": {
+                    "default": "Keep Data in Original S3 Location"
+                },
+                "IPRetentionPeriodAllowedParam": {
+                    "default": "Retention Period (Minutes) for Allowed IP Set"
+                },
+                "IPRetentionPeriodDeniedParam": {
+                    "default": "Retention Period (Minutes) for Denied IP Set"
+                },
+                "SNSEmailParam": {
+                    "default": "Email for receiving notifcation upon Allowed or Denied IP Sets expiration"
+                }
+            }
+        }
+    },
+    "Parameters": {
+        "ActivateAWSManagedRulesParam": {
+            "Type": "String",
+            "Default": "no",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the AWS Managed Rules."
+        },
+        "ActivateSqlInjectionProtectionParam": {
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block common SQL injection attacks."
+        },
+        "ActivateCrossSiteScriptingProtectionParam": {
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block common XSS attacks."
+        },
+        "ActivateHttpFloodProtectionParam": {
+            "Type": "String",
+            "Default": "yes - AWS WAF rate based rule",
+            "AllowedValues": [
+                "yes - AWS WAF rate based rule",
+                "yes - AWS Lambda log parser",
+                "yes - Amazon Athena log parser",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block HTTP flood attacks."
+        },
+        "ActivateScannersProbesProtectionParam": {
+            "Type": "String",
+            "Default": "yes - AWS Lambda log parser",
+            "AllowedValues": [
+                "yes - AWS Lambda log parser",
+                "yes - Amazon Athena log parser",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block scanners and probes."
+        },
+        "ActivateReputationListsProtectionParam": {
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to block requests from IP addresses on third-party reputation lists (supported lists: spamhaus, torproject, and emergingthreats)."
+        },
+        "ActivateBadBotProtectionParam": {
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block bad bots and content scrapers."
+        },
+        "EndpointType": {
+            "Type": "String",
+            "Default": "CloudFront",
+            "AllowedValues": [
+                "CloudFront",
+                "ALB"
+            ],
+            "Description": "Select the type of resource being used."
+        },
+        "AppAccessLogBucket": {
+            "Type": "String",
+            "Default": "",
+            "AllowedPattern": "(^$|^([a-z]|(\\d(?!\\d{0,2}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})))([a-z\\d]|(\\.(?!(\\.|-)))|(-(?!\\.))){1,61}[a-z\\d]$)",
+            "Description": "If you chose yes for the Activate Scanners & Probes Protection parameter, enter a name for the  Amazon S3 bucket where you want to store access logs for your CloudFront distribution or Application  Load Balancer. More about bucket name restriction here: http://amzn.to/1p1YlU5.  If you chose to deactivate this protection, ignore this parameter. "
+        },
+        "ErrorThreshold": {
+            "Type": "Number",
+            "Default": 50,
+            "MinValue": 0,
+            "Description": "If you chose yes for the Activate Scanners & Probes Protection parameter, enter the maximum acceptable bad requests per minute per IP. If you chose to deactivate this protection protection, ignore this parameter."
+        },
+        "RequestThreshold": {
+            "Type": "Number",
+            "Default": 100,
+            "MinValue": 0,
+            "Description": "If you chose yes for the Activate HTTP Flood Protection parameter, enter the maximum acceptable requests per FIVE-minute period per IP address. Please note that AWS WAF rate based rule requires values greater than 100 (if you chose Lambda/Athena log parser options, you can use any value greater than zero). If you chose to deactivate this protection, ignore this parameter."
+        },
+        "WAFBlockPeriod": {
+            "Type": "Number",
+            "Default": 240,
+            "MinValue": 0,
+            "Description": "If you chose yes for the Activate Scanners & Probes Protection or HTTP Flood Lambda/Athena log parser parameters, enter the period (in minutes) to block applicable IP addresses. If you chose to deactivate log parsing, ignore this parameter."
+        },
+        "KeepDataInOriginalS3Location": {
+            "Type": "String",
+            "Default": "No",
+            "AllowedValues": [
+                "Yes",
+                "No"
+            ],
+            "Description": "If you chose Amazon Athena log parser for the Activate Scanners & Probes Protection parameter,  partitioning will be applied to log files and Athena queries. By default log files will be moved from their original location to a partitioned folder structure in s3. Choose Yes if you also want to keep a copy of the logs in their original location. Selecting \"Yes\" will duplicate your log storage. If you did not choose to activate Athena log parsing, ignore this parameter."
+        },
+        "IPRetentionPeriodAllowedParam": {
+            "Type": "Number",
+            "Default": -1,
+            "MinValue": -1,
+            "Description": "If you want to activate IP retention for the Allowed IP set, enter a number (15 or above) as the retention period (minutes).  IP addresses reaching the retention period will expire and be removed from the IP set. A minimum 15-minute retention  period is supported. If you enter a number between 0 and 15, it will be treated as 15. Leave it to default value -1  to disable IP retention."
+        },
+        "IPRetentionPeriodDeniedParam": {
+            "Type": "Number",
+            "Default": -1,
+            "MinValue": -1,
+            "Description": "If you want to activate IP retention for the Denied IP set, enter a number (15 or above) as the retention period (minutes).  IP addresses reaching the retention period will expire and be removed from the IP set. A minimum 15-minute retention  period is supported. If you enter a number between 0 and 15, it will be treated as 15. Leave it to default value -1  to disable IP retention."
+        },
+        "SNSEmailParam": {
+            "Type": "String",
+            "Default": "",
+            "Description": "If you activated IP retention period above and want to receive an email notification when IP addresses expire, enter a valid email address. If you did not activate IP retention or want to disable email notification, leave it blank (default)."
+        }
+    },
+    "Conditions": {
+        "HttpFloodProtectionRateBasedRuleActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateHttpFloodProtectionParam"
+                },
+                "yes - AWS WAF rate based rule"
+            ]
+        },
+        "HttpFloodLambdaLogParser": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateHttpFloodProtectionParam"
+                },
+                "yes - AWS Lambda log parser"
+            ]
+        },
+        "HttpFloodAthenaLogParser": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateHttpFloodProtectionParam"
+                },
+                "yes - Amazon Athena log parser"
+            ]
+        },
+        "HttpFloodProtectionLogParserActivated": {
+            "Fn::Or": [
+                {
+                    "Condition": "HttpFloodLambdaLogParser"
+                },
+                {
+                    "Condition": "HttpFloodAthenaLogParser"
+                }
+            ]
+        },
+        "ScannersProbesLambdaLogParser": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateScannersProbesProtectionParam"
+                },
+                "yes - AWS Lambda log parser"
+            ]
+        },
+        "ScannersProbesAthenaLogParser": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateScannersProbesProtectionParam"
+                },
+                "yes - Amazon Athena log parser"
+            ]
+        },
+        "ScannersProbesProtectionActivated": {
+            "Fn::Or": [
+                {
+                    "Condition": "ScannersProbesLambdaLogParser"
+                },
+                {
+                    "Condition": "ScannersProbesAthenaLogParser"
+                }
+            ]
+        },
+        "AthenaLogParser": {
+            "Fn::Or": [
+                {
+                    "Condition": "HttpFloodAthenaLogParser"
+                },
+                {
+                    "Condition": "ScannersProbesAthenaLogParser"
+                }
+            ]
+        },
+        "LogParser": {
+            "Fn::Or": [
+                {
+                    "Condition": "HttpFloodProtectionLogParserActivated"
+                },
+                {
+                    "Condition": "ScannersProbesProtectionActivated"
+                }
+            ]
+        },
+        "CreateFirehoseAthenaStack": {
+            "Fn::Or": [
+                {
+                    "Condition": "HttpFloodProtectionLogParserActivated"
+                },
+                {
+                    "Condition": "AthenaLogParser"
+                }
+            ]
+        },
+        "ReputationListsProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateReputationListsProtectionParam"
+                },
+                "yes"
+            ]
+        },
+        "BadBotProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateBadBotProtectionParam"
+                },
+                "yes"
+            ]
+        },
+        "AlbEndpoint": {
+            "Fn::Equals": [
+                {
+                    "Ref": "EndpointType"
+                },
+                "ALB"
+            ]
+        },
+        "CustomResourceLambdaAccess": {
+            "Fn::Or": [
+                {
+                    "Condition": "ReputationListsProtectionActivated"
+                },
+                {
+                    "Condition": "AthenaLogParser"
+                }
+            ]
+        },
+        "IPRetentionAllwedPeriod": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "IPRetentionPeriodAllowedParam"
+                        },
+                        -1
+                    ]
+                }
+            ]
+        },
+        "IPRetentionDeniedPeriod": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "IPRetentionPeriodDeniedParam"
+                        },
+                        -1
+                    ]
+                }
+            ]
+        },
+        "IPRetentionPeriod": {
+            "Fn::Or": [
+                {
+                    "Condition": "IPRetentionAllwedPeriod"
+                },
+                {
+                    "Condition": "IPRetentionDeniedPeriod"
+                }
+            ]
+        },
+        "SNSEmailProvided": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "SNSEmailParam"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "SNSEmail": {
+            "Fn::And": [
+                {
+                    "Condition": "IPRetentionPeriod"
+                },
+                {
+                    "Condition": "SNSEmailProvided"
+                }
+            ]
+        }
+    },
+    "Mappings": {
+        "SourceCode": {
+            "General": {
+                "TemplateBucket": "solutions-reference",
+                "SourceBucket": "solutions",
+                "KeyPrefix": "aws-waf-security-automations/v3.2.0"
+            }
+        },
+        "Solution": {
+            "Data": {
+                "SendAnonymousUsageData": "Yes",
+                "LogLevel": "INFO",
+                "SolutionID": "SO0006",
+                "MetricsURL": "https://metrics.awssolutionsbuilder.com/generic"
+            },
+            "Action": {
+                "WAFWhitelistRule": "ALLOW",
+                "WAFBlacklistRule": "BLOCK",
+                "WAFSqlInjectionRule": "BLOCK",
+                "WAFXssRule": "BLOCK",
+                "WAFHttpFloodRateBasedRule": "BLOCK",
+                "WAFHttpFloodRegularRule": "BLOCK",
+                "WAFScannersProbesRule": "BLOCK",
+                "WAFIPReputationListsRule": "BLOCK",
+                "WAFBadBotRule": "BLOCK"
+            },
+            "Athena": {
+                "QueryScheduledRunTime": 5
+            },
+            "UserAgent": {
+                "UserAgentExtra": "AwsSolution/SO0006/v3.2.0"
+            }
+        }
+    },
+    "Resources": {
+        "CheckRequirements": {
+            "Type": "Custom::CheckRequirements",
+            "Properties": {
+                "AthenaLogParser": {
+                    "Fn::If": [
+                        "AthenaLogParser",
+                        "yes",
+                        "no"
+                    ]
+                },
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "Helper",
+                        "Arn"
+                    ]
+                },
+                "HttpFloodProtectionRateBasedRuleActivated": {
+                    "Fn::If": [
+                        "HttpFloodProtectionRateBasedRuleActivated",
+                        "yes",
+                        "no"
+                    ]
+                },
+                "HttpFloodProtectionLogParserActivated": {
+                    "Fn::If": [
+                        "HttpFloodProtectionLogParserActivated",
+                        "yes",
+                        "no"
+                    ]
+                },
+                "ProtectionActivatedScannersProbes": {
+                    "Fn::If": [
+                        "ScannersProbesProtectionActivated",
+                        "yes",
+                        "no"
+                    ]
+                },
+                "AppAccessLogBucket": {
+                    "Ref": "AppAccessLogBucket"
+                },
+                "Region": {
+                    "Ref": "AWS::Region"
+                },
+                "EndpointType": {
+                    "Ref": "EndpointType"
+                },
+                "RequestThreshold": {
+                    "Ref": "RequestThreshold"
+                }
+            }
+        },
+        "FirehoseAthenaStack": {
+            "Type": "AWS::CloudFormation::Stack",
+            "Condition": "CreateFirehoseAthenaStack",
+            "DependsOn": "CheckRequirements",
+            "Properties": {
+                "TemplateURL": {
+                    "Fn::Sub": [
+                        "https://${S3Bucket}.s3.amazonaws.com/${KeyPrefix}/aws-waf-security-automations-firehose-athena.template",
+                        {
+                            "S3Bucket": {
+                                "Fn::FindInMap": [
+                                    "SourceCode",
+                                    "General",
+                                    "TemplateBucket"
+                                ]
+                            },
+                            "KeyPrefix": {
+                                "Fn::FindInMap": [
+                                    "SourceCode",
+                                    "General",
+                                    "KeyPrefix"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "Parameters": {
+                    "ActivateHttpFloodProtectionParam": {
+                        "Ref": "ActivateHttpFloodProtectionParam"
+                    },
+                    "ActivateScannersProbesProtectionParam": {
+                        "Ref": "ActivateScannersProbesProtectionParam"
+                    },
+                    "EndpointType": {
+                        "Ref": "EndpointType"
+                    },
+                    "AppAccessLogBucket": {
+                        "Ref": "AppAccessLogBucket"
+                    },
+                    "ParentStackName": {
+                        "Ref": "AWS::StackName"
+                    },
+                    "WafLogBucket": {
+                        "Fn::If": [
+                            "HttpFloodProtectionLogParserActivated",
+                            {
+                                "Ref": "WafLogBucket"
+                            },
+                            ""
+                        ]
+                    },
+                    "WafLogBucketArn": {
+                        "Fn::If": [
+                            "HttpFloodProtectionLogParserActivated",
+                            {
+                                "Fn::GetAtt": [
+                                    "WafLogBucket",
+                                    "Arn"
+                                ]
+                            },
+                            ""
+                        ]
+                    },
+                    "ErrorThreshold": {
+                        "Ref": "ErrorThreshold"
+                    },
+                    "RequestThreshold": {
+                        "Ref": "RequestThreshold"
+                    },
+                    "WAFBlockPeriod": {
+                        "Ref": "WAFBlockPeriod"
+                    },
+                    "GlueDatabaseName": {
+                        "Fn::If": [
+                            "AthenaLogParser",
+                            {
+                                "Fn::GetAtt": [
+                                    "CreateGlueDatabaseName",
+                                    "DatabaseName"
+                                ]
+                            },
+                            ""
+                        ]
+                    },
+                    "DeliveryStreamName": {
+                        "Fn::If": [
+                            "HttpFloodProtectionLogParserActivated",
+                            {
+                                "Fn::GetAtt": [
+                                    "CreateDeliveryStreamName",
+                                    "DeliveryStreamName"
+                                ]
+                            },
+                            ""
+                        ]
+                    },
+                    "UUID": {
+                        "Fn::GetAtt": [
+                            "CreateUniqueID",
+                            "UUID"
+                        ]
+                    }
+                }
+            }
+        },
+        "WebACLStack": {
+            "Type": "AWS::CloudFormation::Stack",
+            "DependsOn": "CheckRequirements",
+            "Properties": {
+                "TemplateURL": "AWS::NoValue",
+                "Parameters": {
+                    "ActivateAWSManagedRulesParam": {
+                        "Ref": "ActivateAWSManagedRulesParam"
+                    },
+                    "ActivateSqlInjectionProtectionParam": {
+                        "Ref": "ActivateSqlInjectionProtectionParam"
+                    },
+                    "ActivateCrossSiteScriptingProtectionParam": {
+                        "Ref": "ActivateCrossSiteScriptingProtectionParam"
+                    },
+                    "ActivateHttpFloodProtectionParam": {
+                        "Ref": "ActivateHttpFloodProtectionParam"
+                    },
+                    "ActivateScannersProbesProtectionParam": {
+                        "Ref": "ActivateScannersProbesProtectionParam"
+                    },
+                    "ActivateReputationListsProtectionParam": {
+                        "Ref": "ActivateReputationListsProtectionParam"
+                    },
+                    "ActivateBadBotProtectionParam": {
+                        "Ref": "ActivateBadBotProtectionParam"
+                    },
+                    "RequestThreshold": {
+                        "Ref": "RequestThreshold"
+                    },
+                    "RegionScope": {
+                        "Fn::If": [
+                            "AlbEndpoint",
+                            "REGIONAL",
+                            "CLOUDFRONT"
+                        ]
+                    },
+                    "ParentStackName": {
+                        "Ref": "AWS::StackName"
+                    },
+                    "GlueAccessLogsDatabase": {
+                        "Fn::If": [
+                            "AthenaLogParser",
+                            {
+                                "Fn::GetAtt": [
+                                    "FirehoseAthenaStack",
+                                    "Outputs.GlueAccessLogsDatabase"
+                                ]
+                            },
+                            ""
+                        ]
+                    },
+                    "GlueAppAccessLogsTable": {
+                        "Fn::If": [
+                            "ScannersProbesAthenaLogParser",
+                            {
+                                "Fn::GetAtt": [
+                                    "FirehoseAthenaStack",
+                                    "Outputs.GlueAppAccessLogsTable"
+                                ]
+                            },
+                            ""
+                        ]
+                    },
+                    "GlueWafAccessLogsTable": {
+                        "Fn::If": [
+                            "HttpFloodAthenaLogParser",
+                            {
+                                "Fn::GetAtt": [
+                                    "FirehoseAthenaStack",
+                                    "Outputs.GlueWafAccessLogsTable"
+                                ]
+                            },
+                            ""
+                        ]
+                    },
+                    "LogLevel": {
+                        "Fn::FindInMap": [
+                            "Solution",
+                            "Data",
+                            "LogLevel"
+                        ]
+                    }
+                }
+            }
+        },
+        "LambdaRoleHelper": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "S3Access",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:GetBucketLocation",
+                                        "s3:GetObject",
+                                        "s3:ListBucket"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "wafv2:ListWebACLs"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:wafv2:${AWS::Region}:${AWS::AccountId}:regional/webacl/*"
+                                        },
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:wafv2:${AWS::Region}:${AWS::AccountId}:global/webacl/*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*Helper*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W11",
+                            "reason": "LogsAccess permission restricted to account, region and log group name substring (Helper)."
+                        },
+                        {
+                            "id": "W76",
+                            "reason": "The policy is long as it is scoped down to all the IP set ARNs and function ARNs."
+                        }
+                    ]
+                }
+            }
+        },
+        "LambdaRoleBadBot": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*BadBotParser*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudFormationAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudformation:DescribeStacks",
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetAndUpdateIPSet",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "wafv2:GetIPSet",
+                                        "wafv2:UpdateIPSet"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "WebACLStack",
+                                                "Outputs.WAFBadBotSetV4Arn"
+                                            ]
+                                        },
+                                        {
+                                            "Fn::GetAtt": [
+                                                "WebACLStack",
+                                                "Outputs.WAFBadBotSetV6Arn"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudWatchAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudwatch:GetMetricStatistics",
+                                    "Resource": [
+                                        "*"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W11",
+                            "reason": "LogsAccess - permission restricted to account, region and log group name substring (BadBotParser); CloudFormationAccess - account, region and stack name; CloudWatchAccess - this actions does not support resource-level permissions"
+                        }
+                    ]
+                }
+            }
+        },
+        "LambdaRoleReputationListsParser": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "ReputationListsProtectionActivated",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Policies": [
+                    {
+                        "PolicyName": "CloudWatchLogs",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*ReputationListsParser*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetAndUpdateIPSet",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "wafv2:GetIPSet",
+                                        "wafv2:UpdateIPSet"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "WebACLStack",
+                                                "Outputs.WAFReputationListsSetV4Arn"
+                                            ]
+                                        },
+                                        {
+                                            "Fn::GetAtt": [
+                                                "WebACLStack",
+                                                "Outputs.WAFReputationListsSetV6Arn"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudFormationAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudformation:DescribeStacks",
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudWatchAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudwatch:GetMetricStatistics",
+                                    "Resource": [
+                                        "*"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W11",
+                            "reason": "CloudWatchLogs - permission restricted to account, region and log group name substring (ReputationListsParser); CloudFormationAccess - account, region and stack name; CloudWatchAccess - this actions does not support resource-level permissions"
+                        }
+                    ]
+                }
+            }
+        },
+        "LambdaRoleLogParser": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "LogParser",
+            "DependsOn": "WebACLStack",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "Fn::If": [
+                            "ScannersProbesProtectionActivated",
+                            {
+                                "PolicyName": "ScannersProbesProtectionActivatedAccess",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": "s3:GetObject",
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}/*"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": "s3:PutObject",
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}/${AWS::StackName}-app_log_out.json"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}/${AWS::StackName}-app_log_conf.json"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "wafv2:GetIPSet",
+                                                "wafv2:UpdateIPSet"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::GetAtt": [
+                                                        "WebACLStack",
+                                                        "Outputs.WAFScannersProbesSetV4Arn"
+                                                    ]
+                                                },
+                                                {
+                                                    "Fn::GetAtt": [
+                                                        "WebACLStack",
+                                                        "Outputs.WAFScannersProbesSetV6Arn"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "Fn::If": [
+                            "ScannersProbesAthenaLogParser",
+                            {
+                                "PolicyName": "ScannersProbesAthenaLogParserAccess",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "athena:GetNamedQuery",
+                                                "athena:StartQueryExecution"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/WAF*"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "s3:GetBucketLocation",
+                                                "s3:GetObject",
+                                                "s3:ListBucket",
+                                                "s3:ListBucketMultipartUploads",
+                                                "s3:ListMultipartUploadParts",
+                                                "s3:AbortMultipartUpload",
+                                                "s3:CreateBucket",
+                                                "s3:PutObject"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}/athena_results/*"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "glue:GetTable",
+                                                "glue:GetPartitions"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${WebACLStack.Outputs.GlueAccessLogsDatabase}"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${WebACLStack.Outputs.GlueAccessLogsDatabase}/${WebACLStack.Outputs.GlueAppAccessLogsTable}"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "Fn::If": [
+                            "HttpFloodProtectionLogParserActivated",
+                            {
+                                "PolicyName": "HttpFloodProtectionLogParserActivatedAccess",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": "s3:GetObject",
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${WafLogBucket}/*"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": "s3:PutObject",
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${WafLogBucket}/${AWS::StackName}-waf_log_out.json"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${WafLogBucket}/${AWS::StackName}-waf_log_conf.json"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "wafv2:GetIPSet",
+                                                "wafv2:UpdateIPSet"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::GetAtt": [
+                                                        "WebACLStack",
+                                                        "Outputs.WAFHttpFloodSetV4Arn"
+                                                    ]
+                                                },
+                                                {
+                                                    "Fn::GetAtt": [
+                                                        "WebACLStack",
+                                                        "Outputs.WAFHttpFloodSetV6Arn"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "Fn::If": [
+                            "HttpFloodAthenaLogParser",
+                            {
+                                "PolicyName": "HttpFloodAthenaLogParserAccess",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "athena:GetNamedQuery",
+                                                "athena:StartQueryExecution"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/WAF*"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "s3:GetBucketLocation",
+                                                "s3:GetObject",
+                                                "s3:ListBucket",
+                                                "s3:ListBucketMultipartUploads",
+                                                "s3:ListMultipartUploadParts",
+                                                "s3:AbortMultipartUpload",
+                                                "s3:CreateBucket",
+                                                "s3:PutObject"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${WafLogBucket}/athena_results/*"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${WafLogBucket}"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "glue:GetTable",
+                                                "glue:GetPartitions"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${WebACLStack.Outputs.GlueAccessLogsDatabase}"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${WebACLStack.Outputs.GlueAccessLogsDatabase}/${WebACLStack.Outputs.GlueWafAccessLogsTable}"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*LogParser*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudWatchAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudwatch:GetMetricStatistics",
+                                    "Resource": [
+                                        "*"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W11",
+                            "reason": "LogsAccess - permission restricted to account, region and log group name substring (LogParser); CloudWatchAccess - this actions does not support resource-level permissions"
+                        }
+                    ]
+                }
+            }
+        },
+        "LambdaRoleCustomResource": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "S3AccessGeneralAppAccessLog",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:CreateBucket",
+                                        "s3:GetBucketNotification",
+                                        "s3:PutBucketNotification",
+                                        "s3:PutEncryptionConfiguration",
+                                        "s3:PutBucketPublicAccessBlock"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "Fn::If": [
+                            "HttpFloodProtectionLogParserActivated",
+                            {
+                                "PolicyName": "S3AccessGeneralWafLog",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "s3:CreateBucket",
+                                                "s3:GetBucketNotification",
+                                                "s3:PutBucketNotification"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${WafLogBucket}"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "PolicyName": "S3Access",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:GetBucketLocation",
+                                        "s3:GetObject",
+                                        "s3:ListBucket"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "Fn::If": [
+                            "ScannersProbesLambdaLogParser",
+                            {
+                                "PolicyName": "S3AppAccessPut",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": "s3:PutObject",
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}/${AWS::StackName}-app_log_conf.json"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "Fn::If": [
+                            "HttpFloodLambdaLogParser",
+                            {
+                                "PolicyName": "S3WafAccessPut",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": "s3:PutObject",
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${WafLogBucket}/${AWS::StackName}-waf_log_conf.json"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "Fn::If": [
+                            "CustomResourceLambdaAccess",
+                            {
+                                "PolicyName": "LambdaAccess",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": "lambda:InvokeFunction",
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:*AddAthenaPartitions*"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:*ReputationListsParser*"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "PolicyName": "WAFAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "wafv2:GetWebACL",
+                                        "wafv2:UpdateWebACL",
+                                        "wafv2:DeleteLoggingConfiguration"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "WebACLStack",
+                                                "Outputs.WAFWebACLArn"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "IPSetAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "wafv2:GetIPSet",
+                                        "wafv2:DeleteIPSet"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:wafv2:${AWS::Region}:${AWS::AccountId}:regional/ipset/${AWS::StackName}*"
+                                        },
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:wafv2:${AWS::Region}:${AWS::AccountId}:global/ipset/${AWS::StackName}*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "Fn::If": [
+                            "HttpFloodProtectionLogParserActivated",
+                            {
+                                "PolicyName": "WAFLogsAccess",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "wafv2:PutLoggingConfiguration"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::GetAtt": [
+                                                        "WebACLStack",
+                                                        "Outputs.WAFWebACLArn"
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": "iam:CreateServiceLinkedRole",
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:iam::*:role/aws-service-role/wafv2.amazonaws.com/AWSServiceRoleForWAFV2Logging"
+                                                }
+                                            ],
+                                            "Condition": {
+                                                "StringLike": {
+                                                    "iam:AWSServiceName": "wafv2.amazonaws.com"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "PolicyName": "CloudFormationAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudformation:DescribeStacks",
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*CustomResource*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "Fn::If": [
+                            "ScannersProbesProtectionActivated",
+                            {
+                                "PolicyName": "S3BucketLoggingAccess",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "s3:GetBucketLogging",
+                                                "s3:PutBucketLogging"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W11",
+                            "reason": "WAFAccess, WAFRuleAccess, WAFIPSetAccess and WAFRateBasedRuleAccess - restricted to WafArnPrefix/AccountId; CloudFormationAccess - account, region and stack name; LogsAccess - permission restricted to account, region and log group name substring (CustomResource);"
+                        },
+                        {
+                            "id": "W76",
+                            "reason": "The policy is long as it is scoped down to all the IP set ARNs and function ARNs."
+                        }
+                    ]
+                }
+            }
+        },
+        "LambdaRolePartitionS3Logs": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "ScannersProbesAthenaLogParser",
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W11",
+                            "reason": "LogsAccess - permission restricted to account, region and log group name substring (MoveS3LogsForPartition)"
+                        }
+                    ]
+                }
+            },
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "Fn::If": [
+                            "ScannersProbesAthenaLogParser",
+                            {
+                                "PolicyName": "PartitionS3LogsAccess",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "s3:GetObject",
+                                                "s3:DeleteObject",
+                                                "s3:PutObject"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}/*"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*MoveS3LogsForPartition*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "LambdaRoleAddAthenaPartitions": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "AthenaLogParser",
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W11",
+                            "reason": "LogsAccess - permission restricted to account, region and log group name substring (AddAthenaPartitions)"
+                        }
+                    ]
+                }
+            },
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "Fn::If": [
+                            "ScannersProbesAthenaLogParser",
+                            {
+                                "PolicyName": "AddAthenaPartitionsForAppAccessLog",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "s3:GetObject",
+                                                "s3:PutObject",
+                                                "s3:GetBucketLocation",
+                                                "s3:ListBucket",
+                                                "s3:ListBucketMultipartUploads",
+                                                "s3:ListMultipartUploadParts",
+                                                "s3:AbortMultipartUpload",
+                                                "s3:CreateBucket"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}/athena_results/*"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${AppAccessLogBucket}/*"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "athena:StartQueryExecution"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/WAF*"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "glue:GetTable",
+                                                "glue:GetDatabase",
+                                                "glue:UpdateDatabase",
+                                                "glue:CreateDatabase",
+                                                "glue:BatchCreatePartition"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/default"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${WebACLStack.Outputs.GlueAccessLogsDatabase}"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${WebACLStack.Outputs.GlueAccessLogsDatabase}/${WebACLStack.Outputs.GlueAppAccessLogsTable}"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "Fn::If": [
+                            "HttpFloodAthenaLogParser",
+                            {
+                                "PolicyName": "AddAthenaPartitionsForWAFLog",
+                                "PolicyDocument": {
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "s3:GetObject",
+                                                "s3:PutObject",
+                                                "s3:GetBucketLocation",
+                                                "s3:ListBucket",
+                                                "s3:ListBucketMultipartUploads",
+                                                "s3:ListMultipartUploadParts",
+                                                "s3:AbortMultipartUpload",
+                                                "s3:CreateBucket"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${WafLogBucket}/athena_results/*"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${WafLogBucket}"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:s3:::${WafLogBucket}/*"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "athena:StartQueryExecution"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/WAF*"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": [
+                                                "glue:GetTable",
+                                                "glue:GetDatabase",
+                                                "glue:UpdateDatabase",
+                                                "glue:CreateDatabase",
+                                                "glue:BatchCreatePartition"
+                                            ],
+                                            "Resource": [
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/default"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${WebACLStack.Outputs.GlueAccessLogsDatabase}"
+                                                },
+                                                {
+                                                    "Fn::Sub": "arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${WebACLStack.Outputs.GlueAccessLogsDatabase}/${WebACLStack.Outputs.GlueWafAccessLogsTable}"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*AddAthenaPartitions*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "Helper": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Description": "This lambda function verifies the main project's dependencies, requirements and implement auxiliary functions.",
+                "Handler": "helper.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleHelper",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Join": [
+                            "-",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "SourceBucket"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::Region"
+                                }
+                            ]
+                        ]
+                    },
+                    "S3Key": {
+                        "Fn::Join": [
+                            "/",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "KeyPrefix"
+                                    ]
+                                },
+                                "helper.zip"
+                            ]
+                        ]
+                    }
+                },
+                "Environment": {
+                    "Variables": {
+                        "LOG_LEVEL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "LogLevel"
+                            ]
+                        },
+                        "SCOPE": {
+                            "Fn::If": [
+                                "AlbEndpoint",
+                                "REGIONAL",
+                                "CLOUDFRONT"
+                            ]
+                        },
+                        "USER_AGENT_EXTRA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "UserAgent",
+                                "UserAgentExtra"
+                            ]
+                        }
+                    }
+                },
+                "Runtime": "python3.8",
+                "MemorySize": 128,
+                "Timeout": 300
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W89",
+                            "reason": "There is no need to run this lambda in a VPC"
+                        },
+                        {
+                            "id": "W92",
+                            "reason": "There is no need for Reserved Concurrency"
+                        }
+                    ]
+                }
+            }
+        },
+        "LambdaRoleSetIPRetention": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "IPRetentionPeriod",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*SetIPRetention*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "DDBAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "dynamodb:PutItem"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "IPRetentionDDBTable",
+                                                "Arn"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W11",
+                            "reason": "LogsAccess permission restricted to account, region and log group name substring (SetIPRetention)."
+                        }
+                    ]
+                }
+            }
+        },
+        "LambdaRoleRemoveExpiredIP": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "IPRetentionPeriod",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*RemoveExpiredIP*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "wafv2:GetIPSet",
+                                        "wafv2:UpdateIPSet"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "WebACLStack",
+                                                "Outputs.WAFWhitelistSetV4Arn"
+                                            ]
+                                        },
+                                        {
+                                            "Fn::GetAtt": [
+                                                "WebACLStack",
+                                                "Outputs.WAFBlacklistSetV4Arn"
+                                            ]
+                                        },
+                                        {
+                                            "Fn::GetAtt": [
+                                                "WebACLStack",
+                                                "Outputs.WAFWhitelistSetV6Arn"
+                                            ]
+                                        },
+                                        {
+                                            "Fn::GetAtt": [
+                                                "WebACLStack",
+                                                "Outputs.WAFBlacklistSetV6Arn"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "DDBStreamAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "dynamodb:GetShardIterator",
+                                        "dynamodb:DescribeStream",
+                                        "dynamodb:GetRecords",
+                                        "dynamodb:ListStreams"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "IPRetentionDDBTable",
+                                                "StreamArn"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "InvokeLambda",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "lambda:InvokeFunction"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::GetAtt": [
+                                                "IPRetentionDDBTable",
+                                                "StreamArn"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W11",
+                            "reason": "LogsAccess permission restricted to account, region and log group name substring (RemoveExpiredIP)."
+                        }
+                    ]
+                }
+            }
+        },
+        "SNSPublishPolicy": {
+            "Type": "AWS::IAM::Policy",
+            "Condition": "SNSEmail",
+            "Properties": {
+                "PolicyName": "SNSPublishPolicy",
+                "Roles": [
+                    {
+                        "Ref": "LambdaRoleRemoveExpiredIP"
+                    }
+                ],
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "SNS:Publish"
+                            ],
+                            "Resource": [
+                                {
+                                    "Ref": "IPExpirationSNSTopic"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "CreateUniqueID": {
+            "Type": "Custom::CreateUUID",
+            "DependsOn": "CheckRequirements",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "Helper",
+                        "Arn"
+                    ]
+                }
+            }
+        },
+        "CreateDeliveryStreamName": {
+            "Type": "Custom::CreateDeliveryStreamName",
+            "Condition": "HttpFloodProtectionLogParserActivated",
+            "DependsOn": "CheckRequirements",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "Helper",
+                        "Arn"
+                    ]
+                },
+                "StackName": {
+                    "Ref": "AWS::StackName"
+                }
+            }
+        },
+        "CreateGlueDatabaseName": {
+            "Type": "Custom::CreateGlueDatabaseName",
+            "Condition": "AthenaLogParser",
+            "DependsOn": "CheckRequirements",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "Helper",
+                        "Arn"
+                    ]
+                },
+                "StackName": {
+                    "Ref": "AWS::StackName"
+                }
+            }
+        },
+        "WafLogBucket": {
+            "Type": "AWS::S3::Bucket",
+            "Condition": "HttpFloodProtectionLogParserActivated",
+            "DependsOn": "CheckRequirements",
+            "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
+            "Properties": {
+                "AccessControl": "Private",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": [
+                        {
+                            "ServerSideEncryptionByDefault": {
+                                "SSEAlgorithm": "AES256"
+                            }
+                        }
+                    ]
+                },
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": true,
+                    "BlockPublicPolicy": true,
+                    "IgnorePublicAcls": true,
+                    "RestrictPublicBuckets": true
+                },
+                "LoggingConfiguration": {
+                    "DestinationBucketName": {
+                        "Ref": "AccessLoggingBucket"
+                    },
+                    "LogFilePrefix": "WAF_Logs/"
+                }
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W51",
+                            "reason": "WafLogBucket does not require a bucket policy."
+                        }
+                    ]
+                }
+            }
+        },
+        "AccessLoggingBucket": {
+            "Type": "AWS::S3::Bucket",
+            "Condition": "LogParser",
+            "DependsOn": "CheckRequirements",
+            "DeletionPolicy": "Retain",
+            "UpdateReplacePolicy": "Retain",
+            "Properties": {
+                "AccessControl": "LogDeliveryWrite",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": [
+                        {
+                            "ServerSideEncryptionByDefault": {
+                                "SSEAlgorithm": "AES256"
+                            }
+                        }
+                    ]
+                },
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": true,
+                    "BlockPublicPolicy": true,
+                    "IgnorePublicAcls": true,
+                    "RestrictPublicBuckets": true
+                }
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W35",
+                            "reason": "This bucket is an access logging bucket for another bucket and does not require access logging to be configured for it."
+                        }
+                    ]
+                }
+            }
+        },
+        "AccessLoggingBucketPolicy": {
+            "Type": "AWS::S3::BucketPolicy",
+            "Condition": "LogParser",
+            "Properties": {
+                "Bucket": {
+                    "Ref": "AccessLoggingBucket"
+                },
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": "s3:*",
+                            "Condition": {
+                                "Bool": {
+                                    "aws:SecureTransport": "false"
+                                }
+                            },
+                            "Effect": "Deny",
+                            "Principal": "*",
+                            "Resource": [
+                                {
+                                    "Fn::GetAtt": [
+                                        "AccessLoggingBucket",
+                                        "Arn"
+                                    ]
+                                },
+                                {
+                                    "Fn::Join": [
+                                        "/",
+                                        [
+                                            {
+                                                "Fn::GetAtt": [
+                                                    "AccessLoggingBucket",
+                                                    "Arn"
+                                                ]
+                                            },
+                                            "*"
+                                        ]
+                                    ]
+                                }
+                            ],
+                            "Sid": "HttpsOnly"
+                        }
+                    ],
+                    "Version": "2012-10-17"
+                }
+            }
+        },
+        "LogParser": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "LogParser",
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W89",
+                            "reason": "There is no need to run this lambda in a VPC"
+                        },
+                        {
+                            "id": "W92",
+                            "reason": "There is no need for Reserved Concurrency"
+                        }
+                    ]
+                }
+            },
+            "Properties": {
+                "Description": "This function parses access logs to identify suspicious behavior, such as an abnormal amount of errors. It then blocks those IP addresses for a customer-defined period of time.",
+                "Handler": "log-parser.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleLogParser",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Join": [
+                            "-",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "SourceBucket"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::Region"
+                                }
+                            ]
+                        ]
+                    },
+                    "S3Key": {
+                        "Fn::Join": [
+                            "/",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "KeyPrefix"
+                                    ]
+                                },
+                                "log_parser.zip"
+                            ]
+                        ]
+                    }
+                },
+                "Environment": {
+                    "Variables": {
+                        "APP_ACCESS_LOG_BUCKET": {
+                            "Fn::If": [
+                                "ScannersProbesProtectionActivated",
+                                {
+                                    "Ref": "AppAccessLogBucket"
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        },
+                        "WAF_ACCESS_LOG_BUCKET": {
+                            "Fn::If": [
+                                "HttpFloodProtectionLogParserActivated",
+                                {
+                                    "Ref": "WafLogBucket"
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        },
+                        "SEND_ANONYMOUS_USAGE_DATA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "SendAnonymousUsageData"
+                            ]
+                        },
+                        "UUID": {
+                            "Fn::GetAtt": [
+                                "CreateUniqueID",
+                                "UUID"
+                            ]
+                        },
+                        "LIMIT_IP_ADDRESS_RANGES_PER_IP_MATCH_CONDITION": "10000",
+                        "MAX_AGE_TO_UPDATE": "30",
+                        "REGION": {
+                            "Ref": "AWS::Region"
+                        },
+                        "SCOPE": {
+                            "Fn::If": [
+                                "AlbEndpoint",
+                                "REGIONAL",
+                                "CLOUDFRONT"
+                            ]
+                        },
+                        "LOG_TYPE": {
+                            "Fn::If": [
+                                "AlbEndpoint",
+                                "alb",
+                                "cloudfront"
+                            ]
+                        },
+                        "METRIC_NAME_PREFIX": {
+                            "Fn::Join": [
+                                "",
+                                {
+                                    "Fn::Split": [
+                                        "-",
+                                        {
+                                            "Ref": "AWS::StackName"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "LOG_LEVEL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "LogLevel"
+                            ]
+                        },
+                        "STACK_NAME": {
+                            "Ref": "AWS::StackName"
+                        },
+                        "IP_SET_ID_HTTP_FLOODV4": {
+                            "Fn::If": [
+                                "HttpFloodProtectionLogParserActivated",
+                                {
+                                    "Fn::GetAtt": [
+                                        "WebACLStack",
+                                        "Outputs.WAFHttpFloodSetV4Arn"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        },
+                        "IP_SET_ID_HTTP_FLOODV6": {
+                            "Fn::If": [
+                                "HttpFloodProtectionLogParserActivated",
+                                {
+                                    "Fn::GetAtt": [
+                                        "WebACLStack",
+                                        "Outputs.WAFHttpFloodSetV6Arn"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        },
+                        "IP_SET_NAME_HTTP_FLOODV4": {
+                            "Fn::If": [
+                                "HttpFloodProtectionLogParserActivated",
+                                {
+                                    "Fn::GetAtt": [
+                                        "WebACLStack",
+                                        "Outputs.NameHttpFloodSetV4"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        },
+                        "IP_SET_NAME_HTTP_FLOODV6": {
+                            "Fn::If": [
+                                "HttpFloodProtectionLogParserActivated",
+                                {
+                                    "Fn::GetAtt": [
+                                        "WebACLStack",
+                                        "Outputs.NameHttpFloodSetV6"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        },
+                        "IP_SET_ID_SCANNERS_PROBESV4": {
+                            "Fn::If": [
+                                "ScannersProbesProtectionActivated",
+                                {
+                                    "Fn::GetAtt": [
+                                        "WebACLStack",
+                                        "Outputs.WAFScannersProbesSetV4Arn"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        },
+                        "IP_SET_ID_SCANNERS_PROBESV6": {
+                            "Fn::If": [
+                                "ScannersProbesProtectionActivated",
+                                {
+                                    "Fn::GetAtt": [
+                                        "WebACLStack",
+                                        "Outputs.WAFScannersProbesSetV6Arn"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        },
+                        "IP_SET_NAME_SCANNERS_PROBESV4": {
+                            "Fn::If": [
+                                "ScannersProbesProtectionActivated",
+                                {
+                                    "Fn::GetAtt": [
+                                        "WebACLStack",
+                                        "Outputs.NameScannersProbesSetV4"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        },
+                        "IP_SET_NAME_SCANNERS_PROBESV6": {
+                            "Fn::If": [
+                                "ScannersProbesProtectionActivated",
+                                {
+                                    "Fn::GetAtt": [
+                                        "WebACLStack",
+                                        "Outputs.NameScannersProbesSetV6"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::NoValue"
+                                }
+                            ]
+                        },
+                        "WAF_BLOCK_PERIOD": {
+                            "Ref": "WAFBlockPeriod"
+                        },
+                        "ERROR_THRESHOLD": {
+                            "Ref": "ErrorThreshold"
+                        },
+                        "REQUEST_THRESHOLD": {
+                            "Ref": "RequestThreshold"
+                        },
+                        "SOLUTION_ID": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "SolutionID"
+                            ]
+                        },
+                        "METRICS_URL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "MetricsURL"
+                            ]
+                        },
+                        "USER_AGENT_EXTRA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "UserAgent",
+                                "UserAgentExtra"
+                            ]
+                        }
+                    }
+                },
+                "Runtime": "python3.8",
+                "MemorySize": 512,
+                "Timeout": 300
+            }
+        },
+        "MoveS3LogsForPartition": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "ScannersProbesAthenaLogParser",
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W89",
+                            "reason": "There is no need to run this lambda in a VPC"
+                        },
+                        {
+                            "id": "W92",
+                            "reason": "There is no need for Reserved Concurrency"
+                        }
+                    ]
+                }
+            },
+            "Properties": {
+                "Description": "This function is triggered by S3 event to move log files(upon their arrival in s3) from their original location to a partitioned folder structure created per timestamps in file names, hence allowing the usage of partitioning within AWS Athena.",
+                "Handler": "partition_s3_logs.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRolePartitionS3Logs",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Join": [
+                            "-",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "SourceBucket"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::Region"
+                                }
+                            ]
+                        ]
+                    },
+                    "S3Key": {
+                        "Fn::Join": [
+                            "/",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "KeyPrefix"
+                                    ]
+                                },
+                                "log_parser.zip"
+                            ]
+                        ]
+                    }
+                },
+                "Environment": {
+                    "Variables": {
+                        "LOG_LEVEL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "LogLevel"
+                            ]
+                        },
+                        "KEEP_ORIGINAL_DATA": {
+                            "Ref": "KeepDataInOriginalS3Location"
+                        },
+                        "ENDPOINT": {
+                            "Ref": "EndpointType"
+                        },
+                        "USER_AGENT_EXTRA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "UserAgent",
+                                "UserAgentExtra"
+                            ]
+                        }
+                    }
+                },
+                "Runtime": "python3.8",
+                "MemorySize": 512,
+                "Timeout": 300
+            }
+        },
+        "AddAthenaPartitions": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "AthenaLogParser",
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W89",
+                            "reason": "There is no need to run this lambda in a VPC"
+                        },
+                        {
+                            "id": "W92",
+                            "reason": "There is no need for Reserved Concurrency"
+                        }
+                    ]
+                }
+            },
+            "Properties": {
+                "Description": "This function adds a new hourly partition to athena table. It runs every hour, triggered by a CloudWatch event.",
+                "Handler": "add_athena_partitions.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleAddAthenaPartitions",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Join": [
+                            "-",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "SourceBucket"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::Region"
+                                }
+                            ]
+                        ]
+                    },
+                    "S3Key": {
+                        "Fn::Join": [
+                            "/",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "KeyPrefix"
+                                    ]
+                                },
+                                "log_parser.zip"
+                            ]
+                        ]
+                    }
+                },
+                "Environment": {
+                    "Variables": {
+                        "LOG_LEVEL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "LogLevel"
+                            ]
+                        },
+                        "USER_AGENT_EXTRA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "UserAgent",
+                                "UserAgentExtra"
+                            ]
+                        }
+                    }
+                },
+                "Runtime": "python3.8",
+                "MemorySize": 512,
+                "Timeout": 300
+            }
+        },
+        "SetIPRetention": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "IPRetentionPeriod",
+            "Properties": {
+                "Description": "This lambda function processes CW events for WAF UpdateIPSet API calls. It writes relevant ip retention data into a DynamoDB table.",
+                "Handler": "set_ip_retention.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleSetIPRetention",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Join": [
+                            "-",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "SourceBucket"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::Region"
+                                }
+                            ]
+                        ]
+                    },
+                    "S3Key": {
+                        "Fn::Join": [
+                            "/",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "KeyPrefix"
+                                    ]
+                                },
+                                "ip_retention_handler.zip"
+                            ]
+                        ]
+                    }
+                },
+                "Environment": {
+                    "Variables": {
+                        "LOG_LEVEL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "LogLevel"
+                            ]
+                        },
+                        "TABLE_NAME": {
+                            "Ref": "IPRetentionDDBTable"
+                        },
+                        "STACK_NAME": {
+                            "Ref": "AWS::StackName"
+                        },
+                        "IP_RETENTION_PEROID_ALLOWED_MINUTE": {
+                            "Ref": "IPRetentionPeriodAllowedParam"
+                        },
+                        "IP_RETENTION_PEROID_DENIED_MINUTE": {
+                            "Ref": "IPRetentionPeriodDeniedParam"
+                        },
+                        "REMOVE_EXPIRED_IP_LAMBDA_ROLE_NAME": {
+                            "Ref": "LambdaRoleRemoveExpiredIP"
+                        },
+                        "USER_AGENT_EXTRA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "UserAgent",
+                                "UserAgentExtra"
+                            ]
+                        }
+                    }
+                },
+                "Runtime": "python3.8",
+                "MemorySize": 128,
+                "Timeout": 300
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W89",
+                            "reason": "There is no need to run this lambda in a VPC"
+                        },
+                        {
+                            "id": "W92",
+                            "reason": "There is no need for Reserved Concurrency"
+                        }
+                    ]
+                }
+            }
+        },
+        "RemoveExpiredIP": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "IPRetentionPeriod",
+            "Properties": {
+                "Description": "This lambda function processes the DDB streams records (IP) expired by TTL. It removes expired IPs from WAF allowed or denied IP sets.",
+                "Handler": "remove_expired_ip.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleRemoveExpiredIP",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Join": [
+                            "-",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "SourceBucket"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::Region"
+                                }
+                            ]
+                        ]
+                    },
+                    "S3Key": {
+                        "Fn::Join": [
+                            "/",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "KeyPrefix"
+                                    ]
+                                },
+                                "ip_retention_handler.zip"
+                            ]
+                        ]
+                    }
+                },
+                "Environment": {
+                    "Variables": {
+                        "LOG_LEVEL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "LogLevel"
+                            ]
+                        },
+                        "SNS_EMAIL": {
+                            "Fn::If": [
+                                "SNSEmail",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        "SNS_TOPIC_ARN": {
+                            "Fn::If": [
+                                "SNSEmail",
+                                {
+                                    "Ref": "IPExpirationSNSTopic"
+                                },
+                                ""
+                            ]
+                        },
+                        "SEND_ANONYMOUS_USAGE_DATA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "SendAnonymousUsageData"
+                            ]
+                        },
+                        "UUID": {
+                            "Fn::GetAtt": [
+                                "CreateUniqueID",
+                                "UUID"
+                            ]
+                        },
+                        "SOLUTION_ID": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "SolutionID"
+                            ]
+                        },
+                        "METRICS_URL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "MetricsURL"
+                            ]
+                        },
+                        "USER_AGENT_EXTRA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "UserAgent",
+                                "UserAgentExtra"
+                            ]
+                        }
+                    }
+                },
+                "Runtime": "python3.8",
+                "MemorySize": 512,
+                "Timeout": 300
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W89",
+                            "reason": "There is no need to run this lambda in a VPC"
+                        },
+                        {
+                            "id": "W92",
+                            "reason": "There is no need for Reserved Concurrency"
+                        }
+                    ]
+                }
+            }
+        },
+        "LambdaInvokePermissionAppLogParserS3": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "LogParser",
+            "Properties": {
+                "FunctionName": {
+                    "Fn::GetAtt": [
+                        "LogParser",
+                        "Arn"
+                    ]
+                },
+                "Action": "lambda:InvokeFunction",
+                "Principal": "s3.amazonaws.com",
+                "SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                }
+            }
+        },
+        "LambdaInvokePermissionMoveS3LogsForPartition": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "ScannersProbesAthenaLogParser",
+            "Properties": {
+                "FunctionName": {
+                    "Fn::GetAtt": [
+                        "MoveS3LogsForPartition",
+                        "Arn"
+                    ]
+                },
+                "Action": "lambda:InvokeFunction",
+                "Principal": "s3.amazonaws.com",
+                "SourceAccount": {
+                    "Ref": "AWS::AccountId"
+                }
+            }
+        },
+        "LambdaPermissionAddAthenaPartitions": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "AthenaLogParser",
+            "Properties": {
+                "FunctionName": {
+                    "Fn::GetAtt": [
+                        "AddAthenaPartitions",
+                        "Arn"
+                    ]
+                },
+                "Action": "lambda:InvokeFunction",
+                "Principal": "events.amazonaws.com",
+                "SourceArn": {
+                    "Fn::GetAtt": [
+                        "LambdaAddAthenaPartitionsEventsRule",
+                        "Arn"
+                    ]
+                }
+            }
+        },
+        "LambdaInvokePermissionSetIPRetention": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "IPRetentionPeriod",
+            "Properties": {
+                "FunctionName": {
+                    "Ref": "SetIPRetention"
+                },
+                "Action": "lambda:InvokeFunction",
+                "Principal": "events.amazonaws.com",
+                "SourceArn": {
+                    "Fn::GetAtt": [
+                        "SetIPRetentionEventsRule",
+                        "Arn"
+                    ]
+                }
+            }
+        },
+        "LambdaAthenaWAFLogParser": {
+            "Type": "AWS::Events::Rule",
+            "Condition": "HttpFloodAthenaLogParser",
+            "Properties": {
+                "Description": "Security Automation - WAF Logs Athena parser",
+                "ScheduleExpression": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "rate(",
+                            {
+                                "Fn::FindInMap": [
+                                    "Solution",
+                                    "Athena",
+                                    "QueryScheduledRunTime"
+                                ]
+                            },
+                            " minutes)"
+                        ]
+                    ]
+                },
+                "Targets": [
+                    {
+                        "Arn": {
+                            "Fn::GetAtt": [
+                                "LogParser",
+                                "Arn"
+                            ]
+                        },
+                        "Id": "LogParser",
+                        "Input": {
+                            "Fn::Sub": "{\n  \"resourceType\": \"LambdaAthenaWAFLogParser\",\n  \"glueAccessLogsDatabase\": \"${FirehoseAthenaStack.Outputs.GlueAccessLogsDatabase}\",\n  \"accessLogBucket\": \"${WafLogBucket}\",\n  \"glueWafAccessLogsTable\": \"${FirehoseAthenaStack.Outputs.GlueWafAccessLogsTable}\",\n  \"athenaWorkGroup\":\"${FirehoseAthenaStack.Outputs.WAFLogAthenaQueryWorkGroup}\"\n}\n"
+                        }
+                    }
+                ]
+            }
+        },
+        "LambdaInvokePermissionWafLogParserCloudWatch": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "HttpFloodAthenaLogParser",
+            "Properties": {
+                "FunctionName": {
+                    "Ref": "LogParser"
+                },
+                "Action": "lambda:InvokeFunction",
+                "Principal": "events.amazonaws.com",
+                "SourceArn": {
+                    "Fn::GetAtt": [
+                        "LambdaAthenaWAFLogParser",
+                        "Arn"
+                    ]
+                }
+            }
+        },
+        "LambdaAthenaAppLogParser": {
+            "Type": "AWS::Events::Rule",
+            "Condition": "ScannersProbesAthenaLogParser",
+            "Properties": {
+                "Description": "Security Automation - App Logs Athena parser",
+                "ScheduleExpression": "rate(5 minutes)",
+                "Targets": [
+                    {
+                        "Arn": {
+                            "Fn::GetAtt": [
+                                "LogParser",
+                                "Arn"
+                            ]
+                        },
+                        "Id": "LogParser",
+                        "Input": {
+                            "Fn::Sub": "{\n  \"resourceType\": \"LambdaAthenaAppLogParser\",\n  \"glueAccessLogsDatabase\": \"${FirehoseAthenaStack.Outputs.GlueAccessLogsDatabase}\",\n  \"accessLogBucket\": \"${AppAccessLogBucket}\",\n  \"glueAppAccessLogsTable\": \"${FirehoseAthenaStack.Outputs.GlueAppAccessLogsTable}\",\n  \"athenaWorkGroup\": \"${FirehoseAthenaStack.Outputs.WAFAppAccessLogAthenaQueryWorkGroup}\"\n}\n"
+                        }
+                    }
+                ]
+            }
+        },
+        "LambdaAddAthenaPartitionsEventsRule": {
+            "Type": "AWS::Events::Rule",
+            "Condition": "AthenaLogParser",
+            "Properties": {
+                "Description": "Security Automations - Add partitions to Athena table",
+                "ScheduleExpression": "cron(* ? * * * *)",
+                "State": "ENABLED",
+                "Targets": [
+                    {
+                        "Arn": {
+                            "Fn::GetAtt": [
+                                "AddAthenaPartitions",
+                                "Arn"
+                            ]
+                        },
+                        "Id": "LambdaAddAthenaPartitions",
+                        "Input": {
+                            "Fn::Sub": [
+                                "{\n  \"resourceType\": \"LambdaAddAthenaPartitionsEventsRule\",\n  \"glueAccessLogsDatabase\": \"${GlueAccessLogsDatabase}\",\n  \"accessLogBucket\": \"${AppAccessLogBucket}\",\n  \"glueAppAccessLogsTable\": \"${GlueAppAccessLogsTable}\",\n  \"glueWafAccessLogsTable\": \"${GlueWafAccessLogsTable}\",\n  \"wafLogBucket\": \"${WafLogBucket}\",\n  \"athenaWorkGroup\": \"${AthenaWorkGroup}\"\n}",
+                                {
+                                    "GlueAccessLogsDatabase": {
+                                        "Fn::GetAtt": [
+                                            "FirehoseAthenaStack",
+                                            "Outputs.GlueAccessLogsDatabase"
+                                        ]
+                                    },
+                                    "AppAccessLogBucket": {
+                                        "Fn::If": [
+                                            "ScannersProbesAthenaLogParser",
+                                            {
+                                                "Ref": "AppAccessLogBucket"
+                                            },
+                                            ""
+                                        ]
+                                    },
+                                    "GlueAppAccessLogsTable": {
+                                        "Fn::If": [
+                                            "ScannersProbesAthenaLogParser",
+                                            {
+                                                "Fn::GetAtt": [
+                                                    "FirehoseAthenaStack",
+                                                    "Outputs.GlueAppAccessLogsTable"
+                                                ]
+                                            },
+                                            ""
+                                        ]
+                                    },
+                                    "GlueWafAccessLogsTable": {
+                                        "Fn::If": [
+                                            "HttpFloodAthenaLogParser",
+                                            {
+                                                "Fn::GetAtt": [
+                                                    "FirehoseAthenaStack",
+                                                    "Outputs.GlueWafAccessLogsTable"
+                                                ]
+                                            },
+                                            ""
+                                        ]
+                                    },
+                                    "WafLogBucket": {
+                                        "Fn::If": [
+                                            "HttpFloodAthenaLogParser",
+                                            {
+                                                "Ref": "WafLogBucket"
+                                            },
+                                            ""
+                                        ]
+                                    },
+                                    "AthenaWorkGroup": {
+                                        "Fn::GetAtt": [
+                                            "FirehoseAthenaStack",
+                                            "Outputs.WAFAddPartitionAthenaQueryWorkGroup"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "SetIPRetentionEventsRule": {
+            "Type": "AWS::Events::Rule",
+            "Condition": "IPRetentionPeriod",
+            "Properties": {
+                "Description": "AWS WAF Security Automations - Events rule for setting IP retention",
+                "EventPattern": {
+                    "source": [
+                        "aws.wafv2"
+                    ],
+                    "detail-type": [
+                        "AWS API Call via CloudTrail"
+                    ],
+                    "detail": {
+                        "eventSource": [
+                            "wafv2.amazonaws.com"
+                        ],
+                        "eventName": [
+                            "UpdateIPSet"
+                        ],
+                        "requestParameters": {
+                            "name": [
+                                {
+                                    "Fn::GetAtt": [
+                                        "WebACLStack",
+                                        "Outputs.NameWAFWhitelistSetV4"
+                                    ]
+                                },
+                                {
+                                    "Fn::GetAtt": [
+                                        "WebACLStack",
+                                        "Outputs.NameWAFBlacklistSetV4"
+                                    ]
+                                },
+                                {
+                                    "Fn::GetAtt": [
+                                        "WebACLStack",
+                                        "Outputs.NameWAFWhitelistSetV6"
+                                    ]
+                                },
+                                {
+                                    "Fn::GetAtt": [
+                                        "WebACLStack",
+                                        "Outputs.NameWAFBlacklistSetV6"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                "State": "ENABLED",
+                "Targets": [
+                    {
+                        "Arn": {
+                            "Fn::GetAtt": [
+                                "SetIPRetention",
+                                "Arn"
+                            ]
+                        },
+                        "Id": "SetIPRetentionLambda"
+                    }
+                ]
+            }
+        },
+        "LambdaInvokePermissionAppLogParserCloudWatch": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "ScannersProbesAthenaLogParser",
+            "Properties": {
+                "FunctionName": {
+                    "Ref": "LogParser"
+                },
+                "Action": "lambda:InvokeFunction",
+                "Principal": "events.amazonaws.com",
+                "SourceArn": {
+                    "Fn::GetAtt": [
+                        "LambdaAthenaAppLogParser",
+                        "Arn"
+                    ]
+                }
+            }
+        },
+        "ReputationListsParser": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "ReputationListsProtectionActivated",
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W89",
+                            "reason": "There is no need to run this lambda in a VPC"
+                        },
+                        {
+                            "id": "W92",
+                            "reason": "There is no need for Reserved Concurrency"
+                        }
+                    ]
+                }
+            },
+            "Properties": {
+                "Description": "This lambda function checks third-party IP reputation lists hourly for new IP ranges to block. These lists include the Spamhaus Dont Route Or Peer (DROP) and Extended Drop (EDROP) lists, the Proofpoint Emerging Threats IP list, and the Tor exit node list.",
+                "Handler": "reputation-lists.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleReputationListsParser",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Join": [
+                            "-",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "SourceBucket"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::Region"
+                                }
+                            ]
+                        ]
+                    },
+                    "S3Key": {
+                        "Fn::Join": [
+                            "/",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "KeyPrefix"
+                                    ]
+                                },
+                                "reputation_lists_parser.zip"
+                            ]
+                        ]
+                    }
+                },
+                "Runtime": "python3.8",
+                "MemorySize": 512,
+                "Timeout": 300,
+                "Environment": {
+                    "Variables": {
+                        "IP_SET_ID_REPUTATIONV4": {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.WAFReputationListsSetV4Arn"
+                            ]
+                        },
+                        "IP_SET_ID_REPUTATIONV6": {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.WAFReputationListsSetV6Arn"
+                            ]
+                        },
+                        "IP_SET_NAME_REPUTATIONV4": {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.NameReputationListsSetV4"
+                            ]
+                        },
+                        "IP_SET_NAME_REPUTATIONV6": {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.NameReputationListsSetV6"
+                            ]
+                        },
+                        "SCOPE": {
+                            "Fn::If": [
+                                "AlbEndpoint",
+                                "REGIONAL",
+                                "CLOUDFRONT"
+                            ]
+                        },
+                        "LOG_LEVEL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "LogLevel"
+                            ]
+                        },
+                        "URL_LIST": "[{\"url\":\"https://www.spamhaus.org/drop/drop.txt\"},{\"url\":\"https://www.spamhaus.org/drop/edrop.txt\"},{\"url\":\"https://check.torproject.org/exit-addresses\", \"prefix\":\"ExitAddress\"},{\"url\":\"https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt\"}]",
+                        "SOLUTION_ID": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "SolutionID"
+                            ]
+                        },
+                        "METRICS_URL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "MetricsURL"
+                            ]
+                        },
+                        "STACK_NAME": {
+                            "Ref": "AWS::StackName"
+                        },
+                        "LOG_TYPE": {
+                            "Fn::If": [
+                                "AlbEndpoint",
+                                "alb",
+                                "cloudfront"
+                            ]
+                        },
+                        "SEND_ANONYMOUS_USAGE_DATA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "SendAnonymousUsageData"
+                            ]
+                        },
+                        "IPREPUTATIONLIST_METRICNAME": {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.IPReputationListsMetricName"
+                            ]
+                        },
+                        "USER_AGENT_EXTRA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "UserAgent",
+                                "UserAgentExtra"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "ReputationListsParserEventsRule": {
+            "Condition": "ReputationListsProtectionActivated",
+            "Type": "AWS::Events::Rule",
+            "Properties": {
+                "Description": "Security Automation - WAF Reputation Lists",
+                "ScheduleExpression": "rate(1 hour)",
+                "Targets": [
+                    {
+                        "Arn": {
+                            "Fn::GetAtt": [
+                                "ReputationListsParser",
+                                "Arn"
+                            ]
+                        },
+                        "Id": "ReputationListsParser",
+                        "Input": {
+                            "Fn::Sub": [
+                                "{\n  \"URL_LIST\": [\n    {\"url\":\"https://www.spamhaus.org/drop/drop.txt\"},\n    {\"url\":\"https://www.spamhaus.org/drop/edrop.txt\"},\n    {\"url\":\"https://check.torproject.org/exit-addresses\", \"prefix\":\"ExitAddress\"},\n    {\"url\":\"https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt\"}\n  ],\n  \"IP_SET_ID_REPUTATIONV4\": \"${IP_SET_ID_REPUTATIONV4}\",\n  \"IP_SET_ID_REPUTATIONV6\": \"${IP_SET_ID_REPUTATIONV6}\",\n  \"IP_SET_NAME_REPUTATIONV4\": \"${IP_SET_NAME_REPUTATIONV4}\",\n  \"IP_SET_NAME_REPUTATIONV6\": \"${IP_SET_NAME_REPUTATIONV6}\",\n  \"SCOPE\": \"${SCOPE}\"\n}",
+                                {
+                                    "IP_SET_ID_REPUTATIONV4": {
+                                        "Fn::GetAtt": [
+                                            "WebACLStack",
+                                            "Outputs.WAFReputationListsSetV4Arn"
+                                        ]
+                                    },
+                                    "IP_SET_ID_REPUTATIONV6": {
+                                        "Fn::GetAtt": [
+                                            "WebACLStack",
+                                            "Outputs.WAFReputationListsSetV6Arn"
+                                        ]
+                                    },
+                                    "IP_SET_NAME_REPUTATIONV4": {
+                                        "Fn::GetAtt": [
+                                            "WebACLStack",
+                                            "Outputs.NameReputationListsSetV4"
+                                        ]
+                                    },
+                                    "IP_SET_NAME_REPUTATIONV6": {
+                                        "Fn::GetAtt": [
+                                            "WebACLStack",
+                                            "Outputs.NameReputationListsSetV6"
+                                        ]
+                                    },
+                                    "SCOPE": "CLOUDFRONT"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "UpdateReputationListsOnLoad": {
+            "Condition": "ReputationListsProtectionActivated",
+            "Type": "Custom::UpdateReputationLists",
+            "DependsOn": "WebACLStack",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "ReputationListsParser",
+                        "Arn"
+                    ]
+                }
+            }
+        },
+        "LambdaInvokePermissionReputationListsParser": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "ReputationListsProtectionActivated",
+            "Properties": {
+                "FunctionName": {
+                    "Ref": "ReputationListsParser"
+                },
+                "Action": "lambda:InvokeFunction",
+                "Principal": "events.amazonaws.com",
+                "SourceArn": {
+                    "Fn::GetAtt": [
+                        "ReputationListsParserEventsRule",
+                        "Arn"
+                    ]
+                }
+            }
+        },
+        "BadBotParser": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "BadBotProtectionActivated",
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W89",
+                            "reason": "There is no need to run this lambda in a VPC"
+                        },
+                        {
+                            "id": "W92",
+                            "reason": "There is no need for Reserved Concurrency"
+                        }
+                    ]
+                }
+            },
+            "Properties": {
+                "Description": "This lambda function will intercepts and inspects trap endpoint requests to extract its IP address, and then add it to an AWS WAF block list.",
+                "Handler": "access-handler.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleBadBot",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Join": [
+                            "-",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "SourceBucket"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::Region"
+                                }
+                            ]
+                        ]
+                    },
+                    "S3Key": {
+                        "Fn::Join": [
+                            "/",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "KeyPrefix"
+                                    ]
+                                },
+                                "access_handler.zip"
+                            ]
+                        ]
+                    }
+                },
+                "Environment": {
+                    "Variables": {
+                        "SCOPE": {
+                            "Fn::If": [
+                                "AlbEndpoint",
+                                "REGIONAL",
+                                "CLOUDFRONT"
+                            ]
+                        },
+                        "IP_SET_ID_BAD_BOTV4": {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.WAFBadBotSetV4Arn"
+                            ]
+                        },
+                        "IP_SET_ID_BAD_BOTV6": {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.WAFBadBotSetV6Arn"
+                            ]
+                        },
+                        "IP_SET_NAME_BAD_BOTV4": {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.NameBadBotSetV4"
+                            ]
+                        },
+                        "IP_SET_NAME_BAD_BOTV6": {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.NameBadBotSetV6"
+                            ]
+                        },
+                        "SEND_ANONYMOUS_USAGE_DATA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "SendAnonymousUsageData"
+                            ]
+                        },
+                        "UUID": {
+                            "Fn::GetAtt": [
+                                "CreateUniqueID",
+                                "UUID"
+                            ]
+                        },
+                        "REGION": {
+                            "Ref": "AWS::Region"
+                        },
+                        "LOG_TYPE": {
+                            "Fn::If": [
+                                "AlbEndpoint",
+                                "alb",
+                                "cloudfront"
+                            ]
+                        },
+                        "METRIC_NAME_PREFIX": {
+                            "Fn::Join": [
+                                "",
+                                {
+                                    "Fn::Split": [
+                                        "-",
+                                        {
+                                            "Ref": "AWS::StackName"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "LOG_LEVEL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "LogLevel"
+                            ]
+                        },
+                        "SOLUTION_ID": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "SolutionID"
+                            ]
+                        },
+                        "METRICS_URL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "MetricsURL"
+                            ]
+                        },
+                        "STACK_NAME": {
+                            "Ref": "AWS::StackName"
+                        },
+                        "USER_AGENT_EXTRA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "UserAgent",
+                                "UserAgentExtra"
+                            ]
+                        }
+                    }
+                },
+                "Runtime": "python3.8",
+                "MemorySize": 128,
+                "Timeout": 300
+            }
+        },
+        "LambdaInvokePermissionBadBot": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "FunctionName": {
+                    "Fn::GetAtt": [
+                        "BadBotParser",
+                        "Arn"
+                    ]
+                },
+                "Action": "lambda:InvokeFunction",
+                "Principal": "apigateway.amazonaws.com"
+            }
+        },
+        "ApiGatewayBadBot": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "CheckRequirements",
+            "Properties": {
+                "Name": "Security Automation - WAF Bad Bot API",
+                "Description": "API created by AWS WAF Security Automation CloudFormation template. This endpoint will be used to capture bad bots."
+            }
+        },
+        "ApiGatewayBadBotResource": {
+            "Type": "AWS::ApiGateway::Resource",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "ParentId": {
+                    "Fn::GetAtt": [
+                        "ApiGatewayBadBot",
+                        "RootResourceId"
+                    ]
+                },
+                "PathPart": "{proxy+}"
+            }
+        },
+        "ApiGatewayBadBotMethodRoot": {
+            "Type": "AWS::ApiGateway::Method",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "LambdaInvokePermissionBadBot",
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "ResourceId": {
+                    "Fn::GetAtt": [
+                        "ApiGatewayBadBot",
+                        "RootResourceId"
+                    ]
+                },
+                "HttpMethod": "ANY",
+                "AuthorizationType": "NONE",
+                "RequestParameters": {
+                    "method.request.header.X-Forwarded-For": false
+                },
+                "Integration": {
+                    "Type": "AWS_PROXY",
+                    "IntegrationHttpMethod": "POST",
+                    "Uri": {
+                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BadBotParser.Arn}/invocations"
+                    }
+                }
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W59",
+                            "reason": "Creating a honeypot to lure badbots away."
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayBadBotMethod": {
+            "Type": "AWS::ApiGateway::Method",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "LambdaInvokePermissionBadBot",
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "ResourceId": {
+                    "Ref": "ApiGatewayBadBotResource"
+                },
+                "HttpMethod": "ANY",
+                "AuthorizationType": "NONE",
+                "RequestParameters": {
+                    "method.request.header.X-Forwarded-For": false
+                },
+                "Integration": {
+                    "Type": "AWS_PROXY",
+                    "IntegrationHttpMethod": "POST",
+                    "Uri": {
+                        "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BadBotParser.Arn}/invocations"
+                    }
+                }
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W59",
+                            "reason": "Creating a honeypot to lure badbots away."
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayBadBotDeployment": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "ApiGatewayBadBotMethod",
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "Description": "CloudFormation Deployment Stage",
+                "StageName": "CFDeploymentStage"
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W45",
+                            "reason": "Log not needed for this component."
+                        },
+                        {
+                            "id": "W68",
+                            "reason": "Usage Plan not required."
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayBadBotStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "DeploymentId": {
+                    "Ref": "ApiGatewayBadBotDeployment"
+                },
+                "Description": "Production Stage",
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "StageName": "ProdStage",
+                "AccessLogSetting": {
+                    "DestinationArn": {
+                        "Fn::GetAtt": [
+                            "ApiGatewayBadBotStageAccessLogGroup",
+                            "Arn"
+                        ]
+                    },
+                    "Format": "{\"sourceIp\": \"$context.identity.sourceIp\", \"caller\": \"$context.identity.caller\", \"user\": \"$context.identity.user\", \"requestTime\": \"$context.requestTime\", \"httpMethod\": \"$context.httpMethod\", \"resourcePath\": \"$context.resourcePath\", \"protocol\": \"$context.protocol\", \"status\": \"$context.status\", \"responseLength\": \"$context.responseLength\", \"requestId\": \"$context.requestId\"}"
+                }
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W64",
+                            "reason": "Usage Plan not required."
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayBadBotStageAccessLogGroup": {
+            "Type": "AWS::Logs::LogGroup",
+            "Condition": "BadBotProtectionActivated",
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W84",
+                            "reason": "Encryption not required: no sensitive data logged to CloudWatch."
+                        },
+                        {
+                            "id": "W86",
+                            "reason": "Leave the configuration of the expiration of the log data in CloudWatch log group to user due to potential compliance regulations."
+                        }
+                    ]
+                }
+            }
+        },
+        "ApiGatewayBadBotCloudWatchRole": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Action": "sts:AssumeRole",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "apigateway.amazonaws.com"
+                            }
+                        }
+                    ]
+                },
+                "Policies": [
+                    {
+                        "PolicyName": "LambdaRestApiCloudWatchRole",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:DescribeLogGroups",
+                                        "logs:DescribeLogStreams",
+                                        "logs:PutLogEvents",
+                                        "logs:GetLogEvents",
+                                        "logs:FilterLogEvents"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "ApiGatewayBadBotAccount": {
+            "Type": "AWS::ApiGateway::Account",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "CloudWatchRoleArn": {
+                    "Fn::GetAtt": [
+                        "ApiGatewayBadBotCloudWatchRole",
+                        "Arn"
+                    ]
+                }
+            },
+            "DependsOn": [
+                "ApiGatewayBadBot"
+            ]
+        },
+        "CustomResource": {
+            "Type": "AWS::Lambda::Function",
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W89",
+                            "reason": "There is no need to run this lambda in a VPC"
+                        },
+                        {
+                            "id": "W92",
+                            "reason": "There is no need for Reserved Concurrency"
+                        }
+                    ]
+                }
+            },
+            "Properties": {
+                "Description": "This lambda function configures the Web ACL rules based on the features enabled in the CloudFormation template.",
+                "Handler": "custom-resource.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleCustomResource",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Join": [
+                            "-",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "SourceBucket"
+                                    ]
+                                },
+                                {
+                                    "Ref": "AWS::Region"
+                                }
+                            ]
+                        ]
+                    },
+                    "S3Key": {
+                        "Fn::Join": [
+                            "/",
+                            [
+                                {
+                                    "Fn::FindInMap": [
+                                        "SourceCode",
+                                        "General",
+                                        "KeyPrefix"
+                                    ]
+                                },
+                                "custom_resource.zip"
+                            ]
+                        ]
+                    }
+                },
+                "Environment": {
+                    "Variables": {
+                        "LOG_LEVEL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "LogLevel"
+                            ]
+                        },
+                        "SCOPE": {
+                            "Fn::If": [
+                                "AlbEndpoint",
+                                "REGIONAL",
+                                "CLOUDFRONT"
+                            ]
+                        },
+                        "SOLUTION_ID": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "SolutionID"
+                            ]
+                        },
+                        "METRICS_URL": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "Data",
+                                "MetricsURL"
+                            ]
+                        },
+                        "USER_AGENT_EXTRA": {
+                            "Fn::FindInMap": [
+                                "Solution",
+                                "UserAgent",
+                                "UserAgentExtra"
+                            ]
+                        }
+                    }
+                },
+                "Runtime": "python3.8",
+                "MemorySize": 128,
+                "Timeout": 300
+            }
+        },
+        "ConfigureAWSWAFLogs": {
+            "Type": "Custom::ConfigureAWSWAFLogs",
+            "Condition": "HttpFloodProtectionLogParserActivated",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "CustomResource",
+                        "Arn"
+                    ]
+                },
+                "WAFWebACLArn": {
+                    "Fn::GetAtt": [
+                        "WebACLStack",
+                        "Outputs.WAFWebACLArn"
+                    ]
+                },
+                "DeliveryStreamArn": {
+                    "Fn::GetAtt": [
+                        "FirehoseAthenaStack",
+                        "Outputs.FirehoseWAFLogsDeliveryStreamArn"
+                    ]
+                }
+            }
+        },
+        "ConfigureAppAccessLogBucket": {
+            "Type": "Custom::ConfigureAppAccessLogBucket",
+            "Condition": "ScannersProbesProtectionActivated",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "CustomResource",
+                        "Arn"
+                    ]
+                },
+                "Region": {
+                    "Ref": "AWS::Region"
+                },
+                "AppAccessLogBucket": {
+                    "Ref": "AppAccessLogBucket"
+                },
+                "LogParser": {
+                    "Fn::If": [
+                        "LogParser",
+                        {
+                            "Fn::GetAtt": [
+                                "LogParser",
+                                "Arn"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "ScannersProbesLambdaLogParser": {
+                    "Fn::If": [
+                        "ScannersProbesLambdaLogParser",
+                        "yes",
+                        "no"
+                    ]
+                },
+                "ScannersProbesAthenaLogParser": {
+                    "Fn::If": [
+                        "ScannersProbesAthenaLogParser",
+                        "yes",
+                        "no"
+                    ]
+                },
+                "MoveS3LogsForPartition": {
+                    "Fn::If": [
+                        "ScannersProbesAthenaLogParser",
+                        {
+                            "Fn::GetAtt": [
+                                "MoveS3LogsForPartition",
+                                "Arn"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "AccessLoggingBucket": {
+                    "Fn::If": [
+                        "ScannersProbesProtectionActivated",
+                        {
+                            "Ref": "AccessLoggingBucket"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                }
+            }
+        },
+        "ConfigureWafLogBucket": {
+            "Type": "Custom::ConfigureWafLogBucket",
+            "Condition": "HttpFloodProtectionLogParserActivated",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "CustomResource",
+                        "Arn"
+                    ]
+                },
+                "WafLogBucket": {
+                    "Ref": "WafLogBucket"
+                },
+                "LogParser": {
+                    "Fn::If": [
+                        "LogParser",
+                        {
+                            "Fn::GetAtt": [
+                                "LogParser",
+                                "Arn"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "HttpFloodLambdaLogParser": {
+                    "Fn::If": [
+                        "HttpFloodLambdaLogParser",
+                        "yes",
+                        "no"
+                    ]
+                },
+                "HttpFloodAthenaLogParser": {
+                    "Fn::If": [
+                        "HttpFloodAthenaLogParser",
+                        "yes",
+                        "no"
+                    ]
+                }
+            }
+        },
+        "GenerateAppLogParserConfFile": {
+            "Type": "Custom::GenerateAppLogParserConfFile",
+            "Condition": "ScannersProbesLambdaLogParser",
+            "DependsOn": "ConfigureAppAccessLogBucket",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "CustomResource",
+                        "Arn"
+                    ]
+                },
+                "StackName": {
+                    "Ref": "AWS::StackName"
+                },
+                "AppAccessLogBucket": {
+                    "Ref": "AppAccessLogBucket"
+                },
+                "ErrorThreshold": {
+                    "Ref": "ErrorThreshold"
+                },
+                "WAFBlockPeriod": {
+                    "Ref": "WAFBlockPeriod"
+                }
+            }
+        },
+        "GenerateWafLogParserConfFile": {
+            "Type": "Custom::GenerateWafLogParserConfFile",
+            "Condition": "HttpFloodLambdaLogParser",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "CustomResource",
+                        "Arn"
+                    ]
+                },
+                "StackName": {
+                    "Ref": "AWS::StackName"
+                },
+                "WafAccessLogBucket": {
+                    "Ref": "WafLogBucket"
+                },
+                "RequestThreshold": {
+                    "Ref": "RequestThreshold"
+                },
+                "WAFBlockPeriod": {
+                    "Ref": "WAFBlockPeriod"
+                }
+            }
+        },
+        "ConfigureWebAcl": {
+            "Type": "Custom::ConfigureWebAcl",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "CustomResource",
+                        "Arn"
+                    ]
+                },
+                "ActivateSqlInjectionProtectionParam": {
+                    "Ref": "ActivateSqlInjectionProtectionParam"
+                },
+                "ActivateCrossSiteScriptingProtectionParam": {
+                    "Ref": "ActivateCrossSiteScriptingProtectionParam"
+                },
+                "ActivateHttpFloodProtectionParam": {
+                    "Ref": "ActivateHttpFloodProtectionParam"
+                },
+                "ActivateScannersProbesProtectionParam": {
+                    "Ref": "ActivateScannersProbesProtectionParam"
+                },
+                "ActivateReputationListsProtectionParam": {
+                    "Ref": "ActivateReputationListsProtectionParam"
+                },
+                "ActivateBadBotProtectionParam": {
+                    "Ref": "ActivateBadBotProtectionParam"
+                },
+                "ActivateAWSManagedRulesParam": {
+                    "Ref": "ActivateAWSManagedRulesParam"
+                },
+                "KeepDataInOriginalS3Location": {
+                    "Ref": "KeepDataInOriginalS3Location"
+                },
+                "IPRetentionPeriodAllowedParam": {
+                    "Ref": "IPRetentionPeriodAllowedParam"
+                },
+                "IPRetentionPeriodDeniedParam": {
+                    "Ref": "IPRetentionPeriodDeniedParam"
+                },
+                "SNSEmailParam": {
+                    "Fn::If": [
+                        "SNSEmail",
+                        "yes",
+                        "no"
+                    ]
+                },
+                "WAFWebACL": {
+                    "Fn::GetAtt": [
+                        "WebACLStack",
+                        "Outputs.WAFWebACL"
+                    ]
+                },
+                "WAFWhitelistSetIPV4": {
+                    "Fn::GetAtt": [
+                        "WebACLStack",
+                        "Outputs.WAFWhitelistSetV4Id"
+                    ]
+                },
+                "WAFBlacklistSetIPV4": {
+                    "Fn::GetAtt": [
+                        "WebACLStack",
+                        "Outputs.WAFBlacklistSetV4Id"
+                    ]
+                },
+                "WAFHttpFloodSetIPV4": {
+                    "Fn::If": [
+                        "HttpFloodProtectionLogParserActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.WAFHttpFloodSetV4Id"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFScannersProbesSetIPV4": {
+                    "Fn::If": [
+                        "ScannersProbesProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.WAFScannersProbesSetV4Id"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFReputationListsSetIPV4": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.WAFReputationListsSetV4Id"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFBadBotSetIPV4": {
+                    "Fn::If": [
+                        "BadBotProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.WAFBadBotSetV4Id"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFWhitelistSetIPV6": {
+                    "Fn::GetAtt": [
+                        "WebACLStack",
+                        "Outputs.WAFWhitelistSetV6Id"
+                    ]
+                },
+                "WAFBlacklistSetIPV6": {
+                    "Fn::GetAtt": [
+                        "WebACLStack",
+                        "Outputs.WAFBlacklistSetV6Id"
+                    ]
+                },
+                "WAFHttpFloodSetIPV6": {
+                    "Fn::If": [
+                        "HttpFloodProtectionLogParserActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.WAFHttpFloodSetV6Id"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFScannersProbesSetIPV6": {
+                    "Fn::If": [
+                        "ScannersProbesProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.WAFScannersProbesSetV6Id"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFReputationListsSetIPV6": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.WAFReputationListsSetV6Id"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFBadBotSetIPV6": {
+                    "Fn::If": [
+                        "BadBotProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.WAFBadBotSetV6Id"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFWhitelistSetIPV4Name": {
+                    "Fn::GetAtt": [
+                        "WebACLStack",
+                        "Outputs.NameWAFWhitelistSetV4"
+                    ]
+                },
+                "WAFBlacklistSetIPV4Name": {
+                    "Fn::GetAtt": [
+                        "WebACLStack",
+                        "Outputs.NameWAFBlacklistSetV4"
+                    ]
+                },
+                "WAFHttpFloodSetIPV4Name": {
+                    "Fn::If": [
+                        "HttpFloodProtectionLogParserActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.NameHttpFloodSetV4"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFScannersProbesSetIPV4Name": {
+                    "Fn::If": [
+                        "ScannersProbesProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.NameScannersProbesSetV4"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFReputationListsSetIPV4Name": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.NameReputationListsSetV4"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFBadBotSetIPV4Name": {
+                    "Fn::If": [
+                        "BadBotProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.NameBadBotSetV4"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFWhitelistSetIPV6Name": {
+                    "Fn::GetAtt": [
+                        "WebACLStack",
+                        "Outputs.NameWAFWhitelistSetV6"
+                    ]
+                },
+                "WAFBlacklistSetIPV6Name": {
+                    "Fn::GetAtt": [
+                        "WebACLStack",
+                        "Outputs.NameWAFBlacklistSetV6"
+                    ]
+                },
+                "WAFHttpFloodSetIPV6Name": {
+                    "Fn::If": [
+                        "HttpFloodProtectionLogParserActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.NameHttpFloodSetV6"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFScannersProbesSetIPV6Name": {
+                    "Fn::If": [
+                        "ScannersProbesProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.NameScannersProbesSetV6"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFReputationListsSetIPV6Name": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.NameReputationListsSetV6"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFBadBotSetIPV6Name": {
+                    "Fn::If": [
+                        "BadBotProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "WebACLStack",
+                                "Outputs.NameBadBotSetV6"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "UUID": {
+                    "Fn::GetAtt": [
+                        "CreateUniqueID",
+                        "UUID"
+                    ]
+                },
+                "Region": {
+                    "Ref": "AWS::Region"
+                },
+                "RequestThreshold": {
+                    "Ref": "RequestThreshold"
+                },
+                "ErrorThreshold": {
+                    "Ref": "ErrorThreshold"
+                },
+                "WAFBlockPeriod": {
+                    "Ref": "WAFBlockPeriod"
+                },
+                "Version": "v3.2.0",
+                "SendAnonymousUsageData": {
+                    "Fn::FindInMap": [
+                        "Solution",
+                        "Data",
+                        "SendAnonymousUsageData"
+                    ]
+                }
+            }
+        },
+        "CustomAddAthenaPartitions": {
+            "Type": "Custom::AddAthenaPartitions",
+            "Condition": "AthenaLogParser",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "CustomResource",
+                        "Arn"
+                    ]
+                },
+                "AddAthenaPartitionsLambda": {
+                    "Fn::GetAtt": [
+                        "AddAthenaPartitions",
+                        "Arn"
+                    ]
+                },
+                "ResourceType": "CustomResource",
+                "GlueAccessLogsDatabase": {
+                    "Fn::GetAtt": [
+                        "FirehoseAthenaStack",
+                        "Outputs.GlueAccessLogsDatabase"
+                    ]
+                },
+                "AppAccessLogBucket": {
+                    "Fn::If": [
+                        "ScannersProbesAthenaLogParser",
+                        {
+                            "Ref": "AppAccessLogBucket"
+                        },
+                        ""
+                    ]
+                },
+                "GlueAppAccessLogsTable": {
+                    "Fn::If": [
+                        "ScannersProbesAthenaLogParser",
+                        {
+                            "Fn::GetAtt": [
+                                "FirehoseAthenaStack",
+                                "Outputs.GlueAppAccessLogsTable"
+                            ]
+                        },
+                        ""
+                    ]
+                },
+                "GlueWafAccessLogsTable": {
+                    "Fn::If": [
+                        "HttpFloodAthenaLogParser",
+                        {
+                            "Fn::GetAtt": [
+                                "FirehoseAthenaStack",
+                                "Outputs.GlueWafAccessLogsTable"
+                            ]
+                        },
+                        ""
+                    ]
+                },
+                "WafLogBucket": {
+                    "Fn::If": [
+                        "HttpFloodAthenaLogParser",
+                        {
+                            "Ref": "WafLogBucket"
+                        },
+                        ""
+                    ]
+                },
+                "AthenaWorkGroup": {
+                    "Fn::GetAtt": [
+                        "FirehoseAthenaStack",
+                        "Outputs.WAFAddPartitionAthenaQueryWorkGroup"
+                    ]
+                }
+            }
+        },
+        "MonitoringDashboard": {
+            "Type": "AWS::CloudWatch::Dashboard",
+            "DependsOn": "CheckRequirements",
+            "Properties": {
+                "DashboardName": {
+                    "Fn::Sub": "${AWS::StackName}-${AWS::Region}"
+                },
+                "DashboardBody": {
+                    "Fn::Sub": [
+                        "{\n  \"widgets\": [{\n    \"type\": \"metric\",\n    \"x\": 0,\n    \"y\": 0,\n    \"width\": 15,\n    \"height\": 10,\n    \"properties\": {\n      \"view\": \"timeSeries\",\n      \"stacked\": false,\n      \"stat\": \"Sum\",\n      \"period\": 300,\n      \"metrics\": [\n        [\"WAF\", \"BlockedRequests\", \"WebACL\", \"${WAFWebACLMetricName}\", \"Rule\", \"ALL\" ${RegionMetric}],\n        [\"WAF\", \"AllowedRequests\", \"WebACL\", \"${WAFWebACLMetricName}\", \"Rule\", \"ALL\" ${RegionMetric}]\n      ],\n      \"region\": \"${RegionProperties}\"\n    }\n  }]\n}",
+                        {
+                            "WAFWebACLMetricName": {
+                                "Fn::GetAtt": [
+                                    "WebACLStack",
+                                    "Outputs.WAFWebACLMetricName"
+                                ]
+                            },
+                            "RegionMetric": {
+                                "Fn::If": [
+                                    "AlbEndpoint",
+                                    {
+                                        "Fn::Sub": ", \"Region\", \"${AWS::Region}\""
+                                    },
+                                    ""
+                                ]
+                            },
+                            "RegionProperties": {
+                                "Fn::If": [
+                                    "AlbEndpoint",
+                                    {
+                                        "Fn::Sub": "${AWS::Region}"
+                                    },
+                                    "us-east-1"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "IPRetentionDDBTable": {
+            "Type": "AWS::DynamoDB::Table",
+            "Condition": "IPRetentionPeriod",
+            "Properties": {
+                "AttributeDefinitions": [
+                    {
+                        "AttributeName": "IPSetId",
+                        "AttributeType": "S"
+                    },
+                    {
+                        "AttributeName": "ExpirationTime",
+                        "AttributeType": "N"
+                    }
+                ],
+                "BillingMode": "PAY_PER_REQUEST",
+                "KeySchema": [
+                    {
+                        "AttributeName": "IPSetId",
+                        "KeyType": "HASH"
+                    },
+                    {
+                        "AttributeName": "ExpirationTime",
+                        "KeyType": "RANGE"
+                    }
+                ],
+                "SSESpecification": {
+                    "SSEEnabled": true,
+                    "SSEType": "KMS"
+                },
+                "StreamSpecification": {
+                    "StreamViewType": "OLD_IMAGE"
+                },
+                "TimeToLiveSpecification": {
+                    "AttributeName": "ExpirationTime",
+                    "Enabled": true
+                }
+            },
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "W78",
+                            "reason": "This DynamoDB table constains transactional ip retention data that will be expired by DynamoDB TTL. The data doesn't need to be retained after its lifecycle ends."
+                        }
+                    ]
+                }
+            }
+        },
+        "IPExpirationSNSTopic": {
+            "Type": "AWS::SNS::Topic",
+            "Condition": "SNSEmail",
+            "Properties": {
+                "DisplayName": "AWS WAF Security Automations IP Expiration Notification",
+                "TopicName": {
+                    "Fn::Join": [
+                        "-",
+                        [
+                            "AWS-WAF-Security-Automations-IP-Expiration-Notification",
+                            {
+                                "Fn::GetAtt": [
+                                    "CreateUniqueID",
+                                    "UUID"
+                                ]
+                            }
+                        ]
+                    ]
+                },
+                "KmsMasterKeyId": "alias/aws/sns"
+            }
+        },
+        "IPExpirationEmailNotification": {
+            "Type": "AWS::SNS::Subscription",
+            "Condition": "SNSEmail",
+            "Properties": {
+                "Endpoint": {
+                    "Ref": "SNSEmailParam"
+                },
+                "Protocol": "email",
+                "TopicArn": {
+                    "Ref": "IPExpirationSNSTopic"
+                }
+            }
+        },
+        "SNSNotificationPolicy": {
+            "Type": "AWS::SNS::TopicPolicy",
+            "Condition": "SNSEmail",
+            "Metadata": {
+                "cfn_nag": {
+                    "rules_to_suppress": [
+                        {
+                            "id": "F18",
+                            "reason": "Condition restricts permissions to current account."
+                        }
+                    ]
+                }
+            },
+            "Properties": {
+                "Topics": [
+                    {
+                        "Ref": "IPExpirationSNSTopic"
+                    }
+                ],
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Sid": "__default_statement_ID",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": [
+                                "SNS:GetTopicAttributes",
+                                "SNS:SetTopicAttributes",
+                                "SNS:AddPermission",
+                                "SNS:RemovePermission",
+                                "SNS:DeleteTopic",
+                                "SNS:Subscribe",
+                                "SNS:ListSubscriptionsByTopic",
+                                "SNS:Publish",
+                                "SNS:Receive"
+                            ],
+                            "Resource": {
+                                "Ref": "IPExpirationSNSTopic"
+                            },
+                            "Condition": {
+                                "StringEquals": {
+                                    "AWS:SourceOwner": {
+                                        "Fn::Sub": "${AWS::AccountId}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Sid": "TrustLambdaToPublishEventsToMyTopic",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "lambda.amazonaws.com"
+                            },
+                            "Action": "SNS:Publish",
+                            "Resource": {
+                                "Ref": "IPExpirationSNSTopic"
+                            }
+                        },
+                        {
+                            "Sid": "AllowPublishThroughSSLOnly",
+                            "Action": "SNS:Publish",
+                            "Effect": "Deny",
+                            "Resource": [
+                                {
+                                    "Ref": "IPExpirationSNSTopic"
+                                }
+                            ],
+                            "Condition": {
+                                "Bool": {
+                                    "aws:SecureTransport": "false"
+                                }
+                            },
+                            "Principal": "*"
+                        }
+                    ]
+                }
+            }
+        },
+        "DDBStreamToLambdaESMapping": {
+            "Type": "AWS::Lambda::EventSourceMapping",
+            "Condition": "IPRetentionPeriod",
+            "Properties": {
+                "Enabled": true,
+                "EventSourceArn": {
+                    "Fn::GetAtt": [
+                        "IPRetentionDDBTable",
+                        "StreamArn"
+                    ]
+                },
+                "FunctionName": {
+                    "Fn::GetAtt": [
+                        "RemoveExpiredIP",
+                        "Arn"
+                    ]
+                },
+                "StartingPosition": "LATEST"
+            }
+        }
+    },
+    "Outputs": {
+        "BadBotHoneypotEndpoint": {
+            "Description": "Bad Bot Honeypot Endpoint",
+            "Value": {
+                "Fn::Sub": "https://${ApiGatewayBadBot}.execute-api.${AWS::Region}.amazonaws.com/${ApiGatewayBadBotStage}"
+            },
+            "Condition": "BadBotProtectionActivated"
+        },
+        "WAFWebACL": {
+            "Description": "AWS WAF WebACL",
+            "Value": {
+                "Fn::GetAtt": [
+                    "WebACLStack",
+                    "Outputs.WAFWebACL"
+                ]
+            }
+        },
+        "WAFWebACLArn": {
+            "Description": "AWS WAF WebACL Arn",
+            "Value": {
+                "Fn::GetAtt": [
+                    "WebACLStack",
+                    "Outputs.WAFWebACLArn"
+                ]
+            }
+        },
+        "WafLogBucket": {
+            "Value": {
+                "Ref": "WafLogBucket"
+            },
+            "Condition": "HttpFloodProtectionLogParserActivated"
+        },
+        "AppAccessLogBucket": {
+            "Value": {
+                "Ref": "AppAccessLogBucket"
+            },
+            "Condition": "ScannersProbesProtectionActivated"
+        },
+        "SolutionVersion": {
+            "Description": "Solution Version Number",
+            "Value": "v3.2.0"
+        }
+    }
+}

--- a/tests/waf_assets/known_bad_inputs_rule.py
+++ b/tests/waf_assets/known_bad_inputs_rule.py
@@ -1,0 +1,29 @@
+import aws_cdk.aws_wafv2 as wafv2
+
+# this is the AWS Managed Rule: AWSManagedRulesKnownBadInputsRuleSet which we include
+# in all our WAFs to guard against the log4j vulnerability
+
+
+def known_bad_inputs_rule():
+    return [
+        ### AWS managed rule - needed to protect against log4j vulnerability
+        wafv2.CfnWebACL.RuleProperty(
+            name="AWS-AWSManagedRulesKnownBadInputsRuleSet",
+            priority=6,
+            statement=wafv2.CfnWebACL.StatementProperty(
+                managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
+                    name="AWSManagedRulesKnownBadInputsRuleSet",
+                    vendor_name="AWS",
+                )
+            ),
+            visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                cloud_watch_metrics_enabled=True,
+                metric_name="AWSManagedRulesKnownBadInputsRuleSet",
+                sampled_requests_enabled=True,
+            ),
+            override_action=wafv2.CfnWebACL.OverrideActionProperty(
+                # assigning to none means it will take the default action rather than count.
+                none=wafv2.CfnWebACL.CountActionProperty()
+            ),
+        ),
+    ]

--- a/tests/waf_assets/nested_template.yaml
+++ b/tests/waf_assets/nested_template.yaml
@@ -1,0 +1,795 @@
+#### CARE!!!!
+# At the moment, in order to be able to add the custom casebook
+# whitelist rule, I've had to effectively hard-code the rule
+# configurations here to match the values set in the protected_cdn_stack
+# (i.e. comment out the conditions where the parameter value is "yes"
+# and comment out resources where the parameter value is "no"). If you change the
+# yes/no values in the protected_cdn stack, you MUST make the corresponding
+# changes here in order for them to take effect.
+# See https://citizensadvice.atlassian.net/browse/OPS-4803
+
+# Priority order set here - leave 2-9 for custom rules added on top of this template
+# 0: whitelist rule
+# 1: blacklist rule
+# 10: aws core managed rule - condition commented out
+# NO flood log-parser rule - rule commented out
+# 11: flood rate-based rule - condition commented out
+# NO scanners & probes rule - rule commented out
+# 12: reputation list rule - condition commented out
+# NO bad bot rule - rule commented out
+# 20: sql injection - condition commented out
+# 30: cross-site scripting (xss) - condition commented out
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  (SO0006-WebACL) - AWS WAF Security Automations v3.2.0: This AWS CloudFormation template helps
+  you provision the AWS WAF Security Automations stack without worrying about creating and
+  configuring the underlying AWS infrastructure.
+
+  **WARNING** This template creates an AWS WAF Web ACL and Amazon CloudWatch custom metrics.
+  You will be billed for the AWS resources used if you create a stack from this template.
+
+Parameters:
+  ActivateAWSManagedRulesParam:
+    Type: String
+  ActivateSqlInjectionProtectionParam:
+    Type: String
+  ActivateCrossSiteScriptingProtectionParam:
+    Type: String
+  ActivateHttpFloodProtectionParam:
+    Type: String
+  ActivateScannersProbesProtectionParam:
+    Type: String
+  ActivateReputationListsProtectionParam:
+    Type: String
+  ActivateBadBotProtectionParam:
+    Type: String
+  RequestThreshold:
+    Type: Number
+  RegionScope:
+    Type: String
+  ParentStackName:
+    Type: String
+  GlueAccessLogsDatabase:
+    Type: String
+  GlueAppAccessLogsTable:
+    Type: String
+  GlueWafAccessLogsTable:
+    Type: String
+  LogLevel:
+    Type: String
+
+Conditions:
+  AWSManagedRulesActivated: !Equals
+    - !Ref ActivateAWSManagedRulesParam
+    - 'yes'
+
+  SqlInjectionProtectionActivated: !Equals
+    - !Ref ActivateSqlInjectionProtectionParam
+    - 'yes'
+
+  CrossSiteScriptingProtectionActivated: !Equals
+    - !Ref ActivateCrossSiteScriptingProtectionParam
+    - 'yes'
+
+  HttpFloodProtectionRateBasedRuleActivated: !Equals
+    - !Ref ActivateHttpFloodProtectionParam
+    - 'yes - AWS WAF rate based rule'
+
+  HttpFloodLambdaLogParser: !Equals
+    - !Ref ActivateHttpFloodProtectionParam
+    - 'yes - AWS Lambda log parser'
+
+  HttpFloodAthenaLogParser: !Equals
+    - !Ref ActivateHttpFloodProtectionParam
+    - 'yes - Amazon Athena log parser'
+
+  HttpFloodProtectionLogParserActivated: !Or
+    - Condition: HttpFloodLambdaLogParser
+    - Condition: HttpFloodAthenaLogParser
+
+  ScannersProbesLambdaLogParser: !Equals
+    - !Ref ActivateScannersProbesProtectionParam
+    - 'yes - AWS Lambda log parser'
+
+  ScannersProbesAthenaLogParser: !Equals
+    - !Ref ActivateScannersProbesProtectionParam
+    - 'yes - Amazon Athena log parser'
+
+  ScannersProbesProtectionActivated: !Or
+    - Condition: ScannersProbesLambdaLogParser
+    - Condition: ScannersProbesAthenaLogParser
+
+  ReputationListsProtectionActivated: !Equals
+    - !Ref ActivateReputationListsProtectionParam
+    - 'yes'
+
+  BadBotProtectionActivated: !Equals
+    - !Ref ActivateBadBotProtectionParam
+    - 'yes'
+
+Mappings:
+  SourceCode:
+    General:
+      TemplateBucket: 'solutions-reference'
+      SourceBucket: 'solutions'
+      KeyPrefix: 'aws-waf-security-automations/v3.2.0'
+
+Resources:
+# Timers
+# There is a rate throttling issue when creating so many calls to create IPSet (1 TPS)
+# By daisychaining these timers at N second intervals we can pace the calls to create new IPSets
+# binding them with DependsOn to the right timer
+
+  TimerWhiteV4:
+    Type: 'Custom::Timer'
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerBlackV4:
+    Type: 'Custom::Timer'
+    DependsOn: TimerWhiteV4
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerHttpFloodV4:
+    Type: 'Custom::Timer'
+    DependsOn: TimerBlackV4
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerScannersV4:
+    Type: 'Custom::Timer'
+    DependsOn: TimerHttpFloodV4
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerReputationV4:
+    DependsOn: TimerScannersV4
+    Type: 'Custom::Timer'
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerBadBotV4:
+    Type: 'Custom::Timer'
+    DependsOn: TimerReputationV4
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerWhiteV6:
+    Type: 'Custom::Timer'
+    DependsOn: TimerBadBotV4
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerBlackV6:
+    Type: 'Custom::Timer'
+    DependsOn: TimerWhiteV6
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerHttpFloodV6:
+    Type: 'Custom::Timer'
+    DependsOn: TimerBlackV6
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerScannersV6:
+    Type: 'Custom::Timer'
+    DependsOn: TimerHttpFloodV6
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerReputationV6:
+    DependsOn: TimerScannersV6
+    Type: 'Custom::Timer'
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+  TimerBadBotV6:
+    Type: 'Custom::Timer'
+    DependsOn: TimerReputationV6
+    Properties:
+      ServiceToken: !GetAtt CustomTimer.Arn
+
+# IPV4 IPSets
+  WAFWhitelistSetV4:
+    Type: 'AWS::WAFv2::IPSet'
+    DependsOn: TimerWhiteV4
+    Properties:
+      Scope: !Sub '${RegionScope}'
+      IPAddressVersion: 'IPV4'
+      Name: !Sub '${ParentStackName}WhitelistSetIPV4'
+      Description: 'Allow List for IPV4 addresses'
+      Addresses: []
+
+  WAFBlacklistSetV4:
+    Type: 'AWS::WAFv2::IPSet'
+    DependsOn: TimerBlackV4
+    Properties:
+      Scope: !Sub '${RegionScope}'
+      IPAddressVersion: 'IPV4'
+      Name: !Sub '${ParentStackName}BlacklistSetIPV4'
+      Description: 'Block Denied List for IPV4 addresses'
+      Addresses: []
+
+#  WAFHttpFloodSetV4:
+#    Type: 'AWS::WAFv2::IPSet'
+#    Condition: HttpFloodProtectionLogParserActivated
+#    DependsOn: TimerHttpFloodV4
+#    Properties:
+#      Scope: !Sub '${RegionScope}'
+#      IPAddressVersion: 'IPV4'
+#      Name: !Sub '${ParentStackName}HTTPFloodSetIPV4'
+#      Description: 'Block HTTP Flood IPV4 addresses'
+#      Addresses: []
+
+#  WAFScannersProbesSetV4:
+#    Type: 'AWS::WAFv2::IPSet'
+#    Condition: ScannersProbesProtectionActivated
+#    DependsOn: TimerScannersV4
+#    Properties:
+#      Scope: !Sub '${RegionScope}'
+#      IPAddressVersion: 'IPV4'
+#      Name: !Sub '${ParentStackName}ScannersProbesSetIPV4'
+#      Description: 'Block Scanners/Probes IPV4 addresses'
+#      Addresses: []
+
+  WAFReputationListsSetV4:
+    Type: 'AWS::WAFv2::IPSet'
+#    Condition: ReputationListsProtectionActivated
+    DependsOn: TimerReputationV4
+    Properties:
+      Scope: !Sub '${RegionScope}'
+      IPAddressVersion: 'IPV4'
+      Name: !Sub '${ParentStackName}IPReputationListsSetIPV4'
+      Description: 'Block Reputation List IPV4 addresses'
+      Addresses: []
+ 
+#  WAFBadBotSetV4:
+#    Type: 'AWS::WAFv2::IPSet'
+#    Condition: BadBotProtectionActivated
+#    DependsOn: TimerBadBotV4
+#    Properties:
+#      Scope: !Sub '${RegionScope}'
+#      IPAddressVersion: 'IPV4'
+#      Name: !Sub '${ParentStackName}IPBadBotSetIPV4'
+#      Description: 'Block Bad Bot IPV4 addresses'
+#      Addresses: []
+
+# IPV6 IPSets
+# Introduced an artificial DependsOn property here on each of the previous IPSets to address
+# a rate throttling issue when creating so many calls to create IPSet
+# The rate limit is 1 call per second to the IPSet API
+  WAFWhitelistSetV6:
+    Type: 'AWS::WAFv2::IPSet'
+    DependsOn: TimerWhiteV6
+    Properties:
+      Scope: !Sub '${RegionScope}'
+      IPAddressVersion: IPV6
+      Name: !Sub '${ParentStackName}WhitelistSetIPV6'
+      Description: 'Allow list for IPV6 addresses'
+      Addresses: []
+
+  WAFBlacklistSetV6:
+    Type: 'AWS::WAFv2::IPSet'
+    DependsOn: TimerBlackV6
+    Properties:
+      Scope: !Sub '${RegionScope}'
+      IPAddressVersion: IPV6
+      Name: !Sub '${ParentStackName}BlacklistSetIPV6'
+      Description: 'Block Denied List for IPV6 addresses'
+      Addresses: []
+
+#  WAFHttpFloodSetV6:
+#    Type: 'AWS::WAFv2::IPSet'
+#    Condition: HttpFloodProtectionLogParserActivated
+#    DependsOn: TimerHttpFloodV6
+#    Properties:
+#      Scope: !Sub '${RegionScope}'
+#      IPAddressVersion: IPV6
+#      Name: !Sub '${ParentStackName}HTTPFloodSetIPV6'
+#      Description: 'Block HTTP Flood IPV6 addresses'
+#      Addresses: []
+
+#  WAFScannersProbesSetV6:
+#    Type: 'AWS::WAFv2::IPSet'
+#    Condition: ScannersProbesProtectionActivated
+#    DependsOn: TimerScannersV6
+#    Properties:
+#      Scope: !Sub '${RegionScope}'
+#      IPAddressVersion: IPV6
+#      Name: !Sub '${ParentStackName}ScannersProbesSetIPV6'
+#      Description: 'Block Scanners/Probes IPV6 addresses'
+#      Addresses: []
+
+  WAFReputationListsSetV6:
+    Type: 'AWS::WAFv2::IPSet'
+#    Condition: ReputationListsProtectionActivated
+    DependsOn: TimerReputationV6
+    Properties:
+      Scope: !Sub '${RegionScope}'
+      IPAddressVersion: IPV6
+      Name: !Sub '${ParentStackName}IPReputationListsSetIPV6'
+      Description: 'Block Reputation List IPV6 addresses'
+      Addresses: []
+
+#  WAFBadBotSetV6:
+#    Type: 'AWS::WAFv2::IPSet'
+#    Condition: BadBotProtectionActivated
+#    DependsOn: TimerBadBotV6
+#    Properties:
+#      Scope: !Sub '${RegionScope}'
+#      IPAddressVersion: IPV6
+#      Name: !Sub '${ParentStackName}IPBadBotSetIPV6'
+#      Description: 'Block Bad Bot IPV6 addresses'
+#      Addresses: []
+
+  LambdaRoleCustomTimer:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*CustomTimer*'
+
+  CustomTimer:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Description: >-
+        This lambda function counts X seconds and can be used to slow down component creation in CloudFormation
+      Handler: 'timer.lambda_handler'
+      Role: !GetAtt LambdaRoleCustomTimer.Arn
+      Code:
+        S3Bucket: !Join ['-', [!FindInMap ["SourceCode", "General", "SourceBucket"], !Ref 'AWS::Region']]
+        S3Key: !Join ['/', [!FindInMap ["SourceCode", "General", "KeyPrefix"], 'timer.zip']]
+      Runtime: python3.8
+      MemorySize: 128
+      Timeout: 300
+      Environment:
+        Variables:
+          SECONDS: '2'
+          LOG_LEVEL: !Ref LogLevel
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+        - id: W89
+          reason: There is no need to run this lambda in a VPC
+        - id: W92
+          reason: There is no need for Reserved Concurrency
+
+# Adding a (priority 0) rule for AWS Managed RuleSet, optionally triggered by params
+
+  WAFWebACL:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Name: !Ref 'ParentStackName'
+      Description: 'Custom WAFWebACL'
+      Scope: !Sub '${RegionScope}'
+      VisibilityConfig: 
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'WAFWebACL']]
+      DefaultAction:
+        Allow: {}
+      Rules:
+#        - !If
+#          - AWSManagedRulesActivated
+        - Name: AWS-AWSManagedRulesCommonRuleSet
+          Priority: 10
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: MetricForAMRCRS
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+#          - !Ref 'AWS::NoValue'
+        - Name: !Sub '${ParentStackName}WhitelistRule'
+          Priority: 0
+          Action:
+            Allow: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'WhitelistRule']]
+          Statement:
+            OrStatement:
+              Statements:
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFWhitelistSetV4.Arn
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFWhitelistSetV6.Arn
+        - Name: !Sub '${ParentStackName}BlacklistRule'
+          Priority: 1
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'BlacklistRule']]
+          Statement:
+            OrStatement:
+              Statements:
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFBlacklistSetV4.Arn
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFBlacklistSetV6.Arn
+#        - !If
+#          - HttpFloodProtectionLogParserActivated
+#          - Name: !Sub '${ParentStackName}HttpFloodRegularRule'
+#            Priority: 3
+#            Action:
+#              Block: {}
+#            VisibilityConfig:
+#              SampledRequestsEnabled: true
+#              CloudWatchMetricsEnabled: true
+#              MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'HttpFloodRegularRule']]
+#            Statement:
+#              OrStatement:
+#                Statements:
+#                  - IPSetReferenceStatement:
+#                      Arn: !GetAtt WAFHttpFloodSetV4.Arn
+#                  - IPSetReferenceStatement:
+#                      Arn: !GetAtt WAFHttpFloodSetV6.Arn
+#          - !Ref 'AWS::NoValue'
+#        - !If
+#          - HttpFloodProtectionRateBasedRuleActivated
+        - Name: !Sub '${ParentStackName}HttpFloodRateBasedRule'
+          Priority: 11
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'HttpFloodRateBasedRule']]
+          Statement:
+            RateBasedStatement:
+              AggregateKeyType: "IP"
+              Limit: !Ref RequestThreshold
+#          - !Ref 'AWS::NoValue'
+#        - !If
+#          - ScannersProbesProtectionActivated
+#        - Name: !Sub '${ParentStackName}ScannersAndProbesRule'
+#          Priority: 12
+#          Action:
+#            Block: {}
+#          VisibilityConfig:
+#            SampledRequestsEnabled: true
+#            CloudWatchMetricsEnabled: true
+#            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'ScannersProbesRule']]
+#          Statement:
+#            OrStatement:
+#              Statements:
+#                - IPSetReferenceStatement:
+#                    Arn: !GetAtt WAFScannersProbesSetV4.Arn
+#                - IPSetReferenceStatement:
+#                    Arn: !GetAtt WAFScannersProbesSetV6.Arn
+#          - !Ref 'AWS::NoValue'
+#        - !If
+#          - ReputationListsProtectionActivated
+        - Name: !Sub '${ParentStackName}IPReputationListsRule'
+          Priority: 12
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'IPReputationListsRule']]
+          Statement:
+            OrStatement:
+              Statements:
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFReputationListsSetV4.Arn
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFReputationListsSetV6.Arn
+#          - !Ref 'AWS::NoValue'
+#        - !If
+#          - BadBotProtectionActivated
+#          - Name: !Sub '${ParentStackName}BadBotRule'
+#            Priority: 7
+#            Action:
+#              Block: {}
+#            VisibilityConfig:
+#              SampledRequestsEnabled: true
+#              CloudWatchMetricsEnabled: true
+#              MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'BadBotRule']]
+#            Statement:
+#              OrStatement:
+#                Statements:
+#                  - IPSetReferenceStatement:
+#                      Arn: !GetAtt WAFBadBotSetV4.Arn
+#                  - IPSetReferenceStatement:
+#                      Arn: !GetAtt WAFBadBotSetV6.Arn
+#          - !Ref 'AWS::NoValue'
+#        - !If
+#          - SqlInjectionProtectionActivated
+        - Name: !Sub '${ParentStackName}SqlInjectionRule'
+          Priority: 20
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'SqlInjectionRule']]
+          Statement:
+            OrStatement:
+              Statements:
+                - SqliMatchStatement:
+                    FieldToMatch:
+                      QueryString: {}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - SqliMatchStatement:
+                    FieldToMatch:
+                      Body: {}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - SqliMatchStatement:
+                    FieldToMatch:
+                      UriPath: {}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - SqliMatchStatement:
+                    FieldToMatch:
+                      SingleHeader: {Name: "Authorization"}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - SqliMatchStatement:
+                    FieldToMatch:
+                      SingleHeader: {Name: "Cookie"}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+#          - !Ref 'AWS::NoValue'
+#        - !If
+#          - CrossSiteScriptingProtectionActivated
+        - Name: !Sub '${ParentStackName}XssRule'
+          Priority: 30
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'XssRule']]
+          Statement:
+            OrStatement:
+              Statements:
+                - XssMatchStatement:
+                    FieldToMatch:
+                      QueryString: {}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - XssMatchStatement:
+                    FieldToMatch:
+                      Body: {}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - XssMatchStatement:
+                    FieldToMatch:
+                      UriPath: {}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+                - XssMatchStatement:
+                    FieldToMatch:
+                      SingleHeader: {Name: "Cookie"}
+                    TextTransformations:
+                      - Priority: 1
+                        Type: URL_DECODE
+                      - Priority: 2
+                        Type: HTML_ENTITY_DECODE
+#          - !Ref 'AWS::NoValue'
+
+Outputs:
+# Arns
+  WAFWhitelistSetV4Arn:
+    Value: !GetAtt WAFWhitelistSetV4.Arn
+
+  WAFBlacklistSetV4Arn:
+    Value: !GetAtt WAFBlacklistSetV4.Arn
+
+#  WAFHttpFloodSetV4Arn:
+#    Value: !GetAtt WAFHttpFloodSetV4.Arn
+#    Condition: HttpFloodProtectionLogParserActivated
+
+#  WAFScannersProbesSetV4Arn:
+#    Value: !GetAtt WAFScannersProbesSetV4.Arn
+#    Condition: ScannersProbesProtectionActivated
+
+  WAFReputationListsSetV4Arn:
+    Value: !GetAtt WAFReputationListsSetV4.Arn
+    Condition: ReputationListsProtectionActivated
+
+#  WAFBadBotSetV4Arn:
+#    Value: !GetAtt WAFBadBotSetV4.Arn
+#    Condition: BadBotProtectionActivated
+
+  WAFWhitelistSetV6Arn:
+    Value: !GetAtt WAFWhitelistSetV6.Arn
+
+  WAFBlacklistSetV6Arn:
+    Value: !GetAtt WAFBlacklistSetV6.Arn
+
+#  WAFHttpFloodSetV6Arn:
+#    Value: !GetAtt WAFHttpFloodSetV6.Arn
+#    Condition: HttpFloodProtectionLogParserActivated
+
+#  WAFScannersProbesSetV6Arn:
+#    Value: !GetAtt WAFScannersProbesSetV6.Arn
+#    Condition: ScannersProbesProtectionActivated
+
+  WAFReputationListsSetV6Arn:
+    Value: !GetAtt WAFReputationListsSetV6.Arn
+    Condition: ReputationListsProtectionActivated
+
+#  WAFBadBotSetV6Arn:
+#    Value: !GetAtt WAFBadBotSetV6.Arn
+#    Condition: BadBotProtectionActivated
+
+# Names
+  NameWAFWhitelistSetV4:
+    Value: !Sub '${ParentStackName}WhitelistSetIPV4'
+
+  NameWAFBlacklistSetV4:
+    Value: !Sub '${ParentStackName}BlacklistSetIPV4'
+
+  NameHttpFloodSetV4:
+    Value: !Sub '${ParentStackName}HTTPFloodSetIPV4'
+    Condition: HttpFloodProtectionLogParserActivated
+
+#  NameScannersProbesSetV4:
+#    Value: !Sub '${ParentStackName}ScannersProbesSetIPV4'
+#    Condition: ScannersProbesProtectionActivated
+
+  NameReputationListsSetV4:
+    Value: !Sub '${ParentStackName}IPReputationListsSetIPV4'
+    Condition: ReputationListsProtectionActivated
+
+#  NameBadBotSetV4:
+#    Value: !Sub '${ParentStackName}IPBadBotSetIPV4'
+#    Condition: BadBotProtectionActivated
+
+  NameWAFWhitelistSetV6:
+    Value: !Sub '${ParentStackName}WhitelistSetIPV6'
+
+  NameWAFBlacklistSetV6:
+    Value: !Sub '${ParentStackName}BlacklistSetIPV6'
+
+  NameHttpFloodSetV6:
+    Value: !Sub '${ParentStackName}HTTPFloodSetIPV6'
+    Condition: HttpFloodProtectionLogParserActivated
+
+#  NameScannersProbesSetV6:
+#    Value: !Sub '${ParentStackName}ScannersProbesSetIPV6'
+#    Condition: ScannersProbesProtectionActivated
+
+  NameReputationListsSetV6:
+    Value: !Sub '${ParentStackName}IPReputationListsSetIPV6'
+    Condition: ReputationListsProtectionActivated
+
+#  NameBadBotSetV6:
+#    Value: !Sub '${ParentStackName}IPBadBotSetIPV6'
+#    Condition: BadBotProtectionActivated
+
+  GlueAccessLogsDatabase:
+    Value: !Ref GlueAccessLogsDatabase
+
+  GlueAppAccessLogsTable:
+    Value: !Ref GlueAppAccessLogsTable
+
+  GlueWafAccessLogsTable:
+    Value: !Ref GlueWafAccessLogsTable
+
+  WAFWebACL:
+    Value: !Ref WAFWebACL
+
+  WAFWebACLArn:
+    Value: !GetAtt WAFWebACL.Arn
+
+  WAFWebACLMetricName:
+    Value: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'MaliciousRequesters']]
+
+  IPReputationListsMetricName:
+    Value: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'IPReputationListsRule']]
+
+  Version:
+    Value: "v3.2.0"
+
+# Ids
+  WAFWhitelistSetV4Id:
+    Value: !GetAtt WAFWhitelistSetV4.Id
+
+  WAFBlacklistSetV4Id:
+    Value: !GetAtt WAFBlacklistSetV4.Id
+
+#  WAFHttpFloodSetV4Id:
+#    Value: !GetAtt WAFHttpFloodSetV4.Id
+#    Condition: HttpFloodProtectionLogParserActivated
+
+#  WAFScannersProbesSetV4Id:
+#    Value: !GetAtt WAFScannersProbesSetV4.Id
+#    Condition: ScannersProbesProtectionActivated
+
+  WAFReputationListsSetV4Id:
+    Value: !GetAtt WAFReputationListsSetV4.Id
+    Condition: ReputationListsProtectionActivated
+
+#  WAFBadBotSetV4Id:
+#    Value: !GetAtt WAFBadBotSetV4.Id
+#    Condition: BadBotProtectionActivated
+
+  WAFWhitelistSetV6Id:
+    Value: !GetAtt WAFWhitelistSetV6.Id
+
+  WAFBlacklistSetV6Id:
+    Value: !GetAtt WAFBlacklistSetV6.Id
+
+#  WAFHttpFloodSetV6Id:
+#    Value: !GetAtt WAFHttpFloodSetV6.Id
+#    Condition: HttpFloodProtectionLogParserActivated
+
+#  WAFScannersProbesSetV6Id:
+#    Value: !GetAtt WAFScannersProbesSetV6.Id
+#    Condition: ScannersProbesProtectionActivated
+
+  WAFReputationListsSetV6Id:
+    Value: !GetAtt WAFReputationListsSetV6.Id
+    Condition: ReputationListsProtectionActivated
+
+#  WAFBadBotSetV6Id:
+#    Value: !GetAtt WAFBadBotSetV6.Id
+#    Condition: BadBotProtectionActivated


### PR DESCRIPTION
Three bits to the PR:

Custom rule for known bad inputs (protects against log4j vulnerability)
Include parameter for users to supply a list of custom rule definitions (default = [])
Allow user to set threshold for flood protection (default = 100, which is the AWS default)

Custom rule definitions have to be constructed in the calling stack.

Tested locally and works with either/both/none of the optional parameters supplied. 

Caveats - yes, this is a bit of a hack - see discussion on https://citizensadvice.atlassian.net/browse/OPS-4803 

@zhelyan I'm not sure I'm really happy with the tests I've written, but `Template.from_stack` doesn't appear to work with `CfnInclude` so I'm not sure how much scope for further testing we have here. I think the onus needs to be on users of the template to check that any wafs they create contain the actual rules they are expecting them to. They will need to do their own testing of any custom rules anyhow.