### PR TITLE
PLATFORM-140: external-secrets 0.6.1

### DIFF
--- a/ca_cdk_constructs/eks/external_secrets/external_secret.py
+++ b/ca_cdk_constructs/eks/external_secrets/external_secret.py
@@ -10,7 +10,7 @@ class ExternalSecret(ApiObject):
     k8s ExternalSecret object
     """
 
-    API_VERSION = "external-secrets.io/v1alpha1"
+    API_VERSION = "external-secrets.io/v1beta1"
     KIND = "ExternalSecret"
 
     def __init__(


### PR DESCRIPTION
updates externalsecrets to `external-secrets.io/v1beta1`.

This changes our custom code, handcrafted to extend the `cdk8s` `ApiObject`. The change is needed because the code is used in referrals and ca-referrals.

The long-term plan is to import the CRD bundle for the new APIs provided in external secrets >= v5 and use the imported objects instead of custom ones.