### PR TITLE
OPS-5438: feat(waf builder) rule to restrict uri to allowed ips

### DIFF
--- a/ca_cdk_constructs/edge_services/waf_v2_builder.py
+++ b/ca_cdk_constructs/edge_services/waf_v2_builder.py
@@ -4,6 +4,7 @@ from typing import Optional
 from ca_cdk_constructs.edge_services.waf_rule_templates import (
     managed_rule_group_property,
     ip_rule_property,
+    restricted_uri_string_property,
 )
 
 
@@ -147,6 +148,37 @@ class WafV2Builder:
                 priority,
                 addresses,
                 allow,
+                count_only,
+                cloud_watch_metrics_enabled,
+            )
+        )
+
+    def add_restricted_uri_string_rule(
+        self,
+        name: str,
+        priority: int,
+        restricted_uri_string: str,
+        allowed_addresses: dict[str, list[str]] = {},
+        count_only: Optional[bool] = False,
+        cloud_watch_metrics_enabled: Optional[bool] = False,
+    ) -> None:
+        """
+        Adds an IP rule to the WAFv2 WebACL.
+
+        :param name: The name of the rule.
+        :param priority: The priority of the rule.
+        :param restricted_uri_string: Any URI containing this string will be blocked except to allowed_addresses
+        :param allowed_addresses: The addresses to use. A dictionary of address types to addresses.
+        :param count_only: Whether to only count the requests. Defaults to False
+        :param cloud_watch_metrics_enabled: Whether to enable CloudWatch metrics. Defaults to False.
+        """
+        self.rules.append(
+            restricted_uri_string_property(
+                self.scope,
+                name,
+                priority,
+                restricted_uri_string,
+                allowed_addresses,
                 count_only,
                 cloud_watch_metrics_enabled,
             )

--- a/ca_cdk_constructs/edge_services/waf_v2_builder.py
+++ b/ca_cdk_constructs/edge_services/waf_v2_builder.py
@@ -23,6 +23,7 @@ class WafV2Builder:
     add_custom_rule: Adds a custom rule to the WAFv2 WebACL.
     add_managed_rule: Adds a managed rule to the WAFv2 WebACL.
     add_ip_rule: Adds an IP rule to the WAFv2 WebACL.
+    add_restricted_uri_string_rule: Adds a rule to the WAFv2 WebACL that restricts access to specific URIs to specific IP addresses
     get_rules: Returns the list of rules added to the WAFv2 WebACL.
     build: Builds the WAFv2 WebACL.
 

--- a/tests/waf/test_waf_v2_builder.py
+++ b/tests/waf/test_waf_v2_builder.py
@@ -116,3 +116,14 @@ def test_waf_v2_get_rules(waf_builder):
     rules = waf_builder.get_rules()
     assert len(rules) == 1
     assert type(rules[0]) == aws_wafv2.CfnWebACL.RuleProperty
+
+
+def test_waf_v2_restricted_uri_string_rule(waf_builder):
+    waf_builder.add_restricted_uri_string_rule(
+        name="RestrictAccessToURIFoo",
+        priority=0,
+        restricted_uri_string="Foo",
+        allowed_addresses={"IPV4": ["1.1.1.1/32"], "IPV6": []}
+    )
+    waf = waf_builder.build()
+    assert len(waf.rules) == 1

--- a/tests/waf/test_waf_v2_builder.py
+++ b/tests/waf/test_waf_v2_builder.py
@@ -125,5 +125,10 @@ def test_waf_v2_restricted_uri_string_rule(waf_builder):
         restricted_uri_string="Foo",
         allowed_addresses={"IPV4": ["1.1.1.1/32"], "IPV6": []}
     )
-    waf = waf_builder.build()
-    assert len(waf.rules) == 1
+    waf_builder.build()
+    rules = waf_builder.get_rules()
+    # basically testing that we block with AND (check for path, NOT ( OR ( in allowed ipv4 or allowed ipv6 sets)))
+    assert type(rules[0]) == aws_wafv2.CfnWebACL.RuleProperty
+    assert type(rules[0].statement.and_statement.statements[0].byte_match_statement) == aws_wafv2.CfnWebACL.ByteMatchStatementProperty
+    assert type(rules[0].statement.and_statement.statements[1].not_statement.statement.or_statement.statements[0].ip_set_reference_statement) ==aws_wafv2.CfnWebACL.IPSetReferenceStatementProperty
+    assert type(rules[0].statement.and_statement.statements[1].not_statement.statement.or_statement.statements[1].ip_set_reference_statement) ==aws_wafv2.CfnWebACL.IPSetReferenceStatementProperty


### PR DESCRIPTION
## Describe your changes
This PR adds a new waf rule which allows access to any URI paths containing a specified string to be restricted to a specific set of allowed IP addresses.

By definition it always blocks (unlike e.g. the `ip_rule`) simply because the logic combination of AND/OR/NOT is more complex if the function is to be truly flexible (e.g. allow except for certain IP addresses). But it could be generalised if required.

This is **not** a breaking change - it does not change any existing functionalilty, simply adds a new function.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have updated the Readme / docs
- [x] If this is a breaking change, I have discussed the roll-out and roll-back plan with the team(s) and I have provided detailed instructions
- [x] If it is a core feature, I have added thorough tests
