### PR TITLE
Add grouping for common updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Europe/London"
+    groups:
+      regular-updates: # Group everything except major version updates and security vulnerabilities
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Describe your changes

Tweaking the dependabot settings to minimise the number of PRs each week. Major updates won't be batched if they happen, and security updates will always be a single PR

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have updated the Readme / docs
- [X] If this is a breaking change, I have discussed the roll-out and roll-back plan with the team(s) and I have provided detailed instructions
- [X] If it is a core feature, I have added thorough tests
