### PR TITLE
Seperate ruff from general updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        exclude-patterns:
+          # Pre-release libraries should be handled individually
+          # to keep PRs easier to understand
+          - "ruff"
+      


### PR DESCRIPTION
## Describe your changes

We can't generally exclude libraries with a major version of 0 from a group, so excluding them by name is the only way to do it. This pulls ruff out of the grouping so the changes that come with minor updates can be handled in the same PR that does the update.

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have updated the Readme / docs
- [X] If this is a breaking change, I have discussed the roll-out and roll-back plan with the team(s) and I have provided detailed instructions
- [X] If it is a core feature, I have added thorough tests
