### PR TITLE
Ignore excess warning about unused missing routetable

### DIFF
--- a/ca_cdk_constructs/eks/eks_cluster_integration.py
+++ b/ca_cdk_constructs/eks/eks_cluster_integration.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import aws_cdk.custom_resources as cr
+import aws_cdk as cdk
 from aws_cdk import CfnOutput, Fn, Stack
 from aws_cdk.aws_ec2 import IVpc
 from aws_cdk.aws_eks import Cluster, OpenIdConnectProvider
@@ -93,6 +94,13 @@ class EksClusterIntegration(Construct):
         oidc_provider = OpenIdConnectProvider.from_open_id_connect_provider_arn(
             self, "ClusterOIDCProvider", open_id_connect_provider_arn=oidc_provider_arn
         )
+
+        # Acknowledge missing route table warnings as workaround for https://github.com/aws/aws-cdk/issues/19786#issuecomment-1892761555
+        # If the Cluster object starts using the routetable later, this might be causing deployment-time issues, but that's unlikely
+        for subnet in private_subnets:
+            cdk.Annotations.of(subnet).acknowledgeWarning(
+                "@aws-cdk/aws-ec2:noSubnetRouteTableId"
+            )
 
         self.cluster = Cluster.from_cluster_attributes(
             self,

--- a/ca_cdk_constructs/eks/eks_cluster_integration.py
+++ b/ca_cdk_constructs/eks/eks_cluster_integration.py
@@ -95,13 +95,6 @@ class EksClusterIntegration(Construct):
             self, "ClusterOIDCProvider", open_id_connect_provider_arn=oidc_provider_arn
         )
 
-        # Acknowledge missing route table warnings as workaround for https://github.com/aws/aws-cdk/issues/19786#issuecomment-1892761555
-        # If the Cluster object starts using the routetable later, this might be causing deployment-time issues, but that's unlikely
-        for subnet in private_subnets:
-            cdk.Annotations.of(subnet).acknowledgeWarning(
-                "@aws-cdk/aws-ec2:noSubnetRouteTableId"
-            )
-
         self.cluster = Cluster.from_cluster_attributes(
             self,
             "Resource",
@@ -113,6 +106,12 @@ class EksClusterIntegration(Construct):
             kubectl_layer=KubectlLayer(self, "KubectlLayer"),
             vpc=vpc,
             prune=prune,  # https://github.com/aws/aws-cdk/issues/19843
+        )
+
+        # Acknowledge missing route table warnings as workaround for https://github.com/aws/aws-cdk/issues/19786#issuecomment-1892761555
+        # If the Cluster object starts using the routetable later, this might be causing deployment-time issues, but that's unlikely
+        cdk.Annotations.of(self.cluster).acknowledge_warning(
+            "@aws-cdk/aws-ec2:noSubnetRouteTableId"
         )
 
         # useful to debug sdk lookup calls


### PR DESCRIPTION
## Describe your changes

When this warning was implemented, it implied that a subnet must be imported using the routetable Id despite the fact that it's an optional property. There's an [open issue for it to be made a warning when the routetable is accessed](https://github.com/aws/aws-cdk/issues/19786)

This workaround comes from that thread and specifically acknowledges the warning on the particular objects that are causing it.

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have updated the Readme / docs
- [X] If this is a breaking change, I have discussed the roll-out and roll-back plan with the team(s) and I have provided detailed instructions
- [ ] If it is a core feature, I have added thorough tests

I haven't added tests for this change, since the EksClusterIntegration object is currently untested, and probably untestable in it's current form.
