### PR TITLE
fix(waf): regional scope not passed to IP rules

### DIFF
--- a/ca_cdk_constructs/edge_services/waf_rule_templates.py
+++ b/ca_cdk_constructs/edge_services/waf_rule_templates.py
@@ -92,6 +92,7 @@ def ip_rule_property(
     allow: bool = False,
     count_only: bool = False,
     cloud_watch_metrics_enabled: bool = False,
+    waf_scope: str = "CLOUDFRONT",
 ) -> waf.CfnWebACL.RuleProperty:
     """A wrapper that returns an `aws_wafv2.CfnWebACL.RuleProperty` object to be used in a list and passed to the CfnWebACL instance.
 
@@ -102,6 +103,7 @@ def ip_rule_property(
     :param allow: Set to True to allow the IP addresses, False to block, defaults to False.
     :param count_only: Set to True to only count and not take action on matching requests, defaults to False.
     :param cloud_watch_metrics_enabled: Set to True to enable logging via Cloudwatch, defaults to Fasle.
+    :param waf_scope: The scope of the WAF ACL. Defaults to CLOUDFRONT.
     :return: aws_cdk.aws_wafv2.CfnWebACL.RuleProperty.
 
     :example:
@@ -144,7 +146,7 @@ def ip_rule_property(
         addresses=addresses.get("IPV4", []),
         description=f"{name}IpSetIPV4",
         ip_address_version="IPV4",
-        scope="CLOUDFRONT",
+        scope=waf_scope,
     ).attr_arn
 
     ipv6_arn = waf.CfnIPSet(
@@ -153,7 +155,7 @@ def ip_rule_property(
         addresses=addresses.get("IPV6", []),
         description=f"{name}IpSetIPV6",
         ip_address_version="IPV6",
-        scope="CLOUDFRONT",
+        scope=waf_scope,
     ).attr_arn
 
     return waf.CfnWebACL.RuleProperty(
@@ -192,6 +194,7 @@ def restricted_uri_string_property(
     allowed_addresses: dict[str, list[str]] = {},
     count_only: bool = False,
     cloud_watch_metrics_enabled: bool = False,
+    waf_scope: str = "CLOUDFRONT",
 ) -> waf.CfnWebACL.RuleProperty:
     """A wrapper that returns an `aws_wafv2.CfnWebACL.RuleProperty` object to be used in a list and passed to the CfnWebACL instance.
 
@@ -202,6 +205,7 @@ def restricted_uri_string_property(
     :param allowed_addresses: A dictionary of strings that specifies zero or more IP addresses or blocks of IP addresses for "IPV4" and "IPV6". Defaults to {}. All addresses must be specified using Classless Inter-Domain Routing (CIDR) notation.
     :param count_only: Set to True to only count and not BLOCK on matching requests, defaults to False.
     :param cloud_watch_metrics_enabled: Set to True to enable logging via Cloudwatch, defaults to Fasle.
+    :param waf_scope: The scope of the WAF ACL. Defaults to CLOUDFRONT.
     :return: aws_cdk.aws_wafv2.CfnWebACL.RuleProperty.
 
     :example:
@@ -241,7 +245,7 @@ def restricted_uri_string_property(
         addresses=allowed_addresses.get("IPV4", []),
         description=f"{name}IpSetIPV4",
         ip_address_version="IPV4",
-        scope="CLOUDFRONT",
+        scope=waf_scope,
     ).attr_arn
 
     ipv6_arn = waf.CfnIPSet(
@@ -250,7 +254,7 @@ def restricted_uri_string_property(
         addresses=allowed_addresses.get("IPV6", []),
         description=f"{name}IpSetIPV6",
         ip_address_version="IPV6",
-        scope="CLOUDFRONT",
+        scope=waf_scope,
     ).attr_arn
 
     return waf.CfnWebACL.RuleProperty(

--- a/ca_cdk_constructs/edge_services/waf_v2_builder.py
+++ b/ca_cdk_constructs/edge_services/waf_v2_builder.py
@@ -55,14 +55,14 @@ class WafV2Builder:
         scope: Construct,
         name: str,
         description: str,
-        waf_scope: Optional[str] = "CLOUDFRONT",
+        waf_scope: str = "CLOUDFRONT",
         log_group: Optional[cf_logs.LogGroup] = None,
         default_action: Optional[waf.CfnWebACL.DefaultActionProperty] = None,
     ) -> None:
         self.rules: typing.List[waf.CfnWebACL.RuleProperty] = []
         self.scope = scope
+        self.waf_scope = waf_scope
         self.name = name
-        self.waf_scope = waf_scope or "CLOUDFRONT"
         self.description = description
         self.log_group = log_group
 
@@ -153,6 +153,7 @@ class WafV2Builder:
                 allow or False,
                 count_only or False,
                 cloud_watch_metrics_enabled or False,
+                waf_scope=self.waf_scope,
             )
         )
 


### PR DESCRIPTION
## Describe your changes

Use the provided WAF scope ("CLOUDFRONT" or "REGIONAL") when creating IP sets.
Before this change, the IP sets were using an hardcoded "CLOUDFRONT" scope, making it impossible to use the construct with a regional scope.

## Checklist before requesting a review
- [X] I have performed a self-review of my code
