### PR TITLE
chore: update python-uv-setup-action to latest SHA

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b
-      - uses: citizensadvice/python-uv-setup-action@7da89585988537f240cbc9833829f3fdfeb7aa2a
+      - uses: citizensadvice/python-uv-setup-action@dac93858ee327eb09052711b17803ecdfa4da10b
         with:
           python_version: 3.13
       - name: Run type check
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b
-      - uses: citizensadvice/python-uv-setup-action@7da89585988537f240cbc9833829f3fdfeb7aa2a
+      - uses: citizensadvice/python-uv-setup-action@dac93858ee327eb09052711b17803ecdfa4da10b
         with:
           python_version: ${{ matrix.python_version }}
       - run: just lint


### PR DESCRIPTION
The currently pinned version of this action uses a Node.js runtime that has reached End of Life. This update pins to the latest release which uses a supported Node.js version.