### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ name: Tests
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     name: MyPy Check


### PR DESCRIPTION
Potential fix for [https://github.com/citizensadvice/ca-cdk-constructs/security/code-scanning/10](https://github.com/citizensadvice/ca-cdk-constructs/security/code-scanning/10)

Add an explicit top-level `permissions` block in `.github/workflows/test.yaml` so every job inherits minimal token scope by default.

Best fix here:
- Insert at workflow root (after `on` is fine) :
  - `permissions:`
  - `contents: read`

Why this is best:
- It addresses the CodeQL finding directly.
- It keeps behavior unchanged for current jobs (they mainly need repository read access for checkout).
- It applies consistently across all jobs (`typecheck`, `test`, `checks-successful`) without duplicating config.
- If a future job needs write access, that specific job can override with a job-level `permissions` block.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
